### PR TITLE
fix(content): update chakra-healing verwachtingstekst

### DIFF
--- a/content/behandelingen/chakra-healing.md
+++ b/content/behandelingen/chakra-healing.md
@@ -26,7 +26,7 @@ image: /images/enisa-healing-handen-in-de-lucht.jpg
 imageAlt: Chakra healing sessie in rustige behandelruimte in Amsterdam Noord
 title: Wat kun je verwachten?
 ---
-Tijdens een chakra healing sessie in mijn praktijk in Amsterdam Noord werk ik intuïtief met de energiestroom in je lichaam om je zeven hoofdchakra’s in balans te brengen. Deze zachte en diep ontspannende behandeling helpt bij het oplossen van energetische blokkades en het herstellen van balans op fysiek, emotioneel en mentaal niveau. Dankzij mijn jarenlange ervaring en aangeboren gave om genezende energie door te geven, ondersteun ik je bij het loslaten van spanningen, pijn en emotionele lasten. Daarnaast voel ik intuïtief aan wat jij nodig hebt, zodat de behandeling bij jou past.
+Tijdens een chakra healing sessie in mijn praktijk in Amsterdam Noord werk ik intuïtief met de energiestroom in je lichaam om je zeven hoofdchakra’s in balans te brengen. Deze diepgaande en ontspannende behandeling helpt bij het oplossen van energetische blokkades.. en het herstellen van balans op fysiek, emotioneel en mentaal niveau. Dankzij mijn jarenlange ervaring en aangeboren gave om genezende energie door te geven, ondersteun ik je bij het loslaten van spanningen, pijn en emotionele lasten. Daarnaast voel ik intuïtief aan wat jij nodig hebt, zodat de behandeling bij jou past.
 ::
 
 ::twee-kolommen


### PR DESCRIPTION
### Motivation
- De tekst in de sectie "Wat kun je verwachten?" van de chakra-healing pagina moest worden aangepast om de bewoording te verfijnen.

### Description
- Vervangen van de zin in `content/behandelingen/chakra-healing.md` van `Deze zachte en diep ontspannende behandeling helpt bij het oplossen van energetische blokkades` naar `Deze diepgaande en ontspannende behandeling helpt bij het oplossen van energetische blokkades..`.

### Testing
- Bevestigd met `rg -n "zachte en diep ontspannende behandeling|diepgaande en ontspannende" content/behandelingen/chakra-healing.md`, `git diff -- content/behandelingen/chakra-healing.md` en `nl -ba content/behandelingen/chakra-healing.md` dat de oude zin is verwijderd en de nieuwe zin aanwezig is; alle checks slaagden.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e23c23e9fc832396454a61a7060d7a)