### PR TITLE
fix: update copy in Andere Behandelingen section

### DIFF
--- a/app/features/treatments/components/RelatedTreatments.vue
+++ b/app/features/treatments/components/RelatedTreatments.vue
@@ -15,7 +15,7 @@ const allTreatments = computed(() => activeTreatments.value.slice(0, 6));
         Andere Behandelingen
       </h2>
       <p class="text-neutral-600 max-w-2xl mx-auto">
-        Ontdek onze andere behandelingen die perfect kunnen aanvullen op jouw welzijnsreis.
+        Ontdek mijn andere behandelingen die een mooie aanvulling kunnen zijn op jouw welzijnsreis.
       </p>
     </header>
 


### PR DESCRIPTION
### Motivation
- Update the intro copy shown in the “Andere Behandelingen” section on treatment pages to the requested, more personal phrasing and ensure the change is applied where the shared UI renders this text.

### Description
- Replaced the sentence in `app/features/treatments/components/RelatedTreatments.vue` from `Ontdek onze andere behandelingen die perfect kunnen aanvullen op jouw welzijnsreis.` to `Ontdek mijn andere behandelingen die een mooie aanvulling kunnen zijn op jouw welzijnsreis.`.

### Testing
- There is no automated test suite in this repository; validation was performed with `rg -n "Ontdek (onze|mijn) andere behandelingen"` which confirmed the new text is present and the old text is removed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e263e4859883238a92d3f8d5e9864b)