### PR TITLE
fix: update homepage treatments heading to "Ontdek Mijn Behandelingen"

### DIFF
--- a/app/features/home/components/HomeTreatments.vue
+++ b/app/features/home/components/HomeTreatments.vue
@@ -3,7 +3,7 @@
     <UContainer>
       <div class="text-center">
         <h2 class="text-3xl font-bold tracking-tight sm:text-4xl">
-          Ontdek Onze Behandelingen
+          Ontdek Mijn Behandelingen
         </h2>
         <p class="mt-4 text-lg leading-8 text-gray-600">
           Kies de behandeling die bij jou past voor heling en ontspanning in


### PR DESCRIPTION
### Motivation
- Pas de koptekst op de home-sectie aan van een zakelijke naar persoonlijke formulering door "Onze" te veranderen in "Mijn".

### Description
- Vervangen van `Ontdek Onze Behandelingen` met `Ontdek Mijn Behandelingen` in `app/features/home/components/HomeTreatments.vue`; `app/pages/index.vue` blijft ongewijzigd omdat die alleen `<HomePage />` renderert.

### Testing
- Bevestigd dat de nieuwe tekst aanwezig is met een gerichte `rg`-zoekopdracht en de wijziging is gecommit; `bun run build` faalde in deze omgeving met `nuxt: command not found`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e27091255483238c8048dbebbe48a9)