### PR TITLE
Voeg 'Amsterdam Noord' toe als gewone tekst onder 'Praktijk' in footer

### DIFF
--- a/app/features/navigation/components/SiteFooter.vue
+++ b/app/features/navigation/components/SiteFooter.vue
@@ -56,6 +56,9 @@
                   Tarieven
                 </ULink>
               </li>
+              <li class="text-neutral-600 dark:text-neutral-300 text-sm">
+                Amsterdam Noord
+              </li>
             </ul>
           </div>
 


### PR DESCRIPTION
### Motivation
- De praktijklocatie moet direct zichtbaar zijn in de footer zodat bezoekers en zoekmachines meteen zien waar de praktijk gevestigd is.

### Description
- Voeg plain text `Amsterdam Noord` toe onder `Tarieven` in de `Praktijk` kolom van `app/features/navigation/components/SiteFooter.vue` zodat het geen link is en direct zichtbaar blijft.

### Testing
- Gedraaid: `bunx eslint app/features/navigation/components/SiteFooter.vue`, welke faalde door een omgeving/ESLint-configuratieprobleem met de Nuxt-generated config (`.nuxt/eslint.config.mjs`) en niet door de inhoudelijke wijziging.
- Geen andere geautomatiseerde tests aanwezig in dit repository volgens `AGENTS.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2714e369483238f6f022ca80c4b0b)