### PR TITLE
fix: update parking rate text on contact page

### DIFF
--- a/app/features/contact/components/ContactMap.vue
+++ b/app/features/contact/components/ContactMap.vue
@@ -41,7 +41,7 @@ const googleMapsUrl = getGoogleMapsUrl();
                 IJplein / Amsterdam Noord.<br>
                 Rijd naar IJplein 69.<br>
                 Er is betaald parkeren rondom IJplein en in de buurt van het
-                gebouw (meestal ± € 2,50 per uur).
+                gebouw (meestal ± € 3,00 per uur).
               </p>
             </UCard>
 


### PR DESCRIPTION
### Motivation
- Update the displayed parking cost on the contact page to reflect the current rate.

### Description
- Replaced the parking sentence in `app/features/contact/components/ContactMap.vue` from `± € 2,50 per uur` to `± € 3,00 per uur`.

### Testing
- Verified the change with `rg -n "Met de auto|€ 3,00 per uur|€ 2,50 per uur"`, inspected the affected lines with `nl -ba app/features/contact/components/ContactMap.vue | sed -n '32,50p'`, and confirmed the `git diff` contains only the intended one-line replacement, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e274ea577883238693fdbb5bc176b6)