### PR TITLE
fix(contact): update metro & bus directions on contact page

### DIFF
--- a/app/features/contact/components/ContactMap.vue
+++ b/app/features/contact/components/ContactMap.vue
@@ -64,15 +64,16 @@ const googleMapsUrl = getGoogleMapsUrl();
                 69.<br><br>
 
                 <span class="font-medium"
-                  >Met metro en bus (vanuit Amsterdam of Amsterdam
-                  Centraal):</span
-                ><br>
-                Neem metro 52 (Noord/Zuidlijn) en stap uit bij station
-                Noord.<br>
-                Vanaf station Noord neem je bus 38 en stap je uit bij halte
-                Valkenweg.<br>
-                Vanaf daar is het ongeveer 350 meter lopen (± 5 minuten) naar
-                IJplein 69.
+                  >Met metro en bus (vanuit Amsterdam Centraal):</span
+                ><br><br>
+                Neem Metro 52 (Noord/Zuidlijn) in de richting van Noord.<br><br>
+                Stap uit bij de eerste halte na het Centraal Station: Station
+                Noorderpark.<br><br>
+                Neem vanaf Station Noorderpark Bus 34 (richting Olof
+                Palmeplein).<br><br>
+                Stap uit bij de halte Valkenweg.<br><br>
+                Vanaf daar is het nog ongeveer 350 meter lopen (± 5 minuten)
+                naar IJplein 69.
               </p>
             </UCard>
 


### PR DESCRIPTION
### Motivation
- De routebeschrijving bij "Met metro en bus" is bijgewerkt om de gevraagde route via Station Noorderpark en Bus 34 weer te geven in plaats van Station Noord en Bus 38.
- Dit is een content-only wijziging waarbij de opmaak en componentstructuur ongewijzigd blijven.

### Description
- Vervangen van de tekstblok voor "Met metro en bus" in `app/features/contact/components/ContactMap.vue` met de nieuwe instructies (Metro 52 richting Noord, uitstappen bij Station Noorderpark, Bus 34 richting Olof Palmeplein, uitstappen bij Valkenweg) en extra regelafstanden zoals gevraagd.
- Alleen stringinhoud in het bestaande component is aangepast; er zijn geen nieuwe bestanden, componenten of routes toegevoegd.

### Testing
- Bevestigd dat de nieuwe tekst aanwezig is door `app/features/contact/components/ContactMap.vue` te inspecteren (`sed -n '58,92p'`).
- Getracht een productiebuild te draaien met `bun run build`, maar dit faalde in de huidige omgeving vanwege ontbrekende `nuxt` (`nuxt: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e276a691f0832397c2795ff858abca)