### PR TITLE
fix(content): update energetische blokkades sessions

### DIFF
--- a/content/behandelingen/energetische-blokkades-opheffen.md
+++ b/content/behandelingen/energetische-blokkades-opheffen.md
@@ -13,11 +13,11 @@ id: da84341d-d8cd-4db7-bacf-7d2495ecccb4
 ::behandeling-sectie
 ---
 items:
-  - "Sessie 1 (90 min): Meditatie gecombineerd met chakra healing - €130"
-  - "Sessie 2 (90 min): Meditatie en healing voor diepere verwerking - €130"
-  - "Sessie 3 (90 min): Twee meditaties om het proces te integreren - €130"
-  - "Sessie 4 (60 min): Afrondende chakra healing behandeling - €85"
-  - "Traject: 4 sessies voor €475 (los boeken: €475)"
+  - "Sessie 1 (120 min): Meditatie gecombineerd met chakra healing - €160"
+  - "Sessie 2 (90 min): Meditatie en healing voor diepere verwerking - €160"
+  - "Sessie 3 (120 min): Twee meditaties om het proces te integreren  met healing - €160"
+  - "Traject: 3 sessies voor €480"
+  - "(Losse sessies: €160 per sessie)"
 image: /images/loslaten-traject.webp
 imageAlt: Traject voor het opheffen van energetische blokkades in Amsterdam Noord
 title: Wat kun je verwachten?


### PR DESCRIPTION
### Motivation
- Update van de sessieopbouw en tarieven in de sectie `Wat kun je verwachten?` zodat duur, prijs en traject overeenkomen met de nieuwe behandeling (verwijderen van sessie 4 en aanpassen naar 3-sessies traject). 

### Description
- Bijgewerkt de `::behandeling-sectie` items in `content/behandelingen/energetische-blokkades-opheffen.md` met nieuwe regels voor sessies 1–3, verwijdering van sessie 4 en de nieuwe traject- en losse-sessieprijzen. 
- Wijziging is vastgelegd met commit message `fix(content): update energetische blokkades sessions`.

### Testing
- Content-assertiescript uitgevoerd en geslaagd (controleert dat alle nieuwe regels aanwezig zijn en oude waarden verwijderd zijn). 
- `git diff --check` uitgevoerd en geen problemen gevonden. 
- `bun run build` uitgevoerd en de build voltooid; er waren alleen bestaande waarschuwingen over ontbrekende Supabase/Studio-configuratie en externe font-metadata. 
- Playwright screenshot geprobeerd als extra verificatie maar faalde door externe factoren (systeemafhankelijke browser libs en ontbrekende Supabase-omgeving), dus geen betrouwbare screenshot opgenomen.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a295a0ccc54832382d8083e9d1a303c)