### PR TITLE
fix: update qualifications on about page

### DIFF
--- a/app/pages/over-mij.vue
+++ b/app/pages/over-mij.vue
@@ -20,17 +20,22 @@ const personSchema = {
   hasCredential: [
     {
       "@type": "EducationalOccupationalCredential",
-      name: "Erkend Wellnessmasseur",
+      name: "SoulKey Therapy Practitioner – SoulKey Academy (opgeleid door Peter Kupers)",
       credentialCategory: "Professional Certification",
     },
     {
       "@type": "EducationalOccupationalCredential",
-      name: "Mindfulnesstrainer MBSR (Mindfulness Academie)",
+      name: "Ericksoniaanse Hypnotherapie – UNLP Academie",
       credentialCategory: "Professional Certification",
     },
     {
       "@type": "EducationalOccupationalCredential",
-      name: "Ericksoniaanse Hypnose - Hypnotherapie (UNLP Instituut)",
+      name: "Mindfulness MBSR Trainer – Centrum voor Mindfulness Amsterdam (opgeleid door drs. Rob Brandsma)",
+      credentialCategory: "Professional Certification",
+    },
+    {
+      "@type": "EducationalOccupationalCredential",
+      name: "Erkend Wellnessmasseur – Anand Opleidingen",
       credentialCategory: "Professional Certification",
     },
   ],
@@ -189,14 +194,10 @@ setPageSEO({
                   name="i-mdi-check-circle"
                   class="w-5 h-5 text-green-500 mt-0.5"
                 />
-                <span class="text-neutral-600">Erkend Wellnessmasseur</span>
-              </li>
-              <li class="flex items-start gap-3">
-                <UIcon
-                  name="i-mdi-check-circle"
-                  class="w-5 h-5 text-green-500 mt-0.5"
-                />
-                <span class="text-neutral-600">Mindfulnesstrainer MBSR</span>
+                <span class="text-neutral-600"
+                  >SoulKey Therapy Practitioner – SoulKey Academy (opgeleid door
+                  Peter Kupers)</span
+                >
               </li>
               <li class="flex items-start gap-3">
                 <UIcon
@@ -204,7 +205,26 @@ setPageSEO({
                   class="w-5 h-5 text-green-500 mt-0.5"
                 />
                 <span class="text-neutral-600"
-                  >Ericksoniaanse Hypnose - Hypnotherapie</span
+                  >Ericksoniaanse Hypnotherapie – UNLP Academie</span
+                >
+              </li>
+              <li class="flex items-start gap-3">
+                <UIcon
+                  name="i-mdi-check-circle"
+                  class="w-5 h-5 text-green-500 mt-0.5"
+                />
+                <span class="text-neutral-600"
+                  >Mindfulness MBSR Trainer – Centrum voor Mindfulness Amsterdam
+                  (opgeleid door drs. Rob Brandsma)</span
+                >
+              </li>
+              <li class="flex items-start gap-3">
+                <UIcon
+                  name="i-mdi-check-circle"
+                  class="w-5 h-5 text-green-500 mt-0.5"
+                />
+                <span class="text-neutral-600"
+                  >Erkend Wellnessmasseur – Anand Opleidingen</span
                 >
               </li>
             </ul>


### PR DESCRIPTION
### Motivation
- De zichtbare `Kwalificaties`-lijst op de pagina `/over-mij` en bijbehorende SEO/schema-metadata moesten worden bijgewerkt naar de nieuw aangeleverde kwalificatieteksten zonder layout- of structuurwijzigingen.

### Description
- Vervangen van de items in `personSchema.hasCredential` in `app/pages/over-mij.vue` met de vier opgegeven kwalificaties inclusief opleidingsinstituten en opleiders.
- Bijgewerkt de zichtbare lijst in de `Kwalificaties` `UCard` binnen `app/pages/over-mij.vue` zodat de UI-tekst overeenkomt met de schema-metadata, waarbij de bestaande HTML/Vue-structuur ongewijzigd bleef.
- Geen nieuwe bestanden, componenten of routes toegevoegd; de wijziging is tekstueel en beperkt tot `app/pages/over-mij.vue`.

### Testing
- Uitgevoerde broncontrole via een `python3`-assertie die bevestigde dat alle vier nieuwe kwalificaties aanwezig zijn en de oude zichtbare labels verwijderd zijn — geslaagd.
- `git diff --check` en `bun run build` gedraaid; de productiebuild voltooid succesvol maar met bestaande waarschuwingen over ontbrekende omgeving (Supabase) en externe font/providers.
- `bunx eslint app/pages/over-mij.vue` kon niet succesvol worden uitgevoerd vanwege een ongeldige import van `.nuxt/eslint.config.mjs` in de repo ESLint-configuratie — geblokkeerd.
- Geautomatiseerde Playwright-screenshot van `/over-mij` geprobeerd maar gefaald doordat de lokale server 500 teruggaf door ontbrekende Supabase-runtime-variabelen en/of systeem/browser dependency issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a853a7bc083238e2023c6c24727de)