### PR TITLE
fix: update Energetische blokkades homepage price to €160

### DIFF
--- a/app/features/home/components/HomeTreatments.vue
+++ b/app/features/home/components/HomeTreatments.vue
@@ -101,7 +101,7 @@ const ANTI_STRESS_HOMEPAGE_DESCRIPTION =
   'In deze sessies leer je om bewust aanwezig te zijn in het hier en nu. Waardoor je meer rust en tevredenheid zult ervaren en meer vertrouwen zult krijgen in jezelf en de toekomst.';
 
 const HYPNOTHERAPIE_HOMEPAGE_PRICE_CENTS = 13000;
-const ENERGETISCHE_BLOKKADES_OPHEFFEN_HOMEPAGE_PRICE_CENTS = 13500;
+const ENERGETISCHE_BLOKKADES_OPHEFFEN_HOMEPAGE_PRICE_CENTS = 16000;
 
 const displayedTreatments = computed(() =>
   allTreatments.value.map((treatment) => {


### PR DESCRIPTION
### Motivation
- Update the homepage price shown for “Energetische blokkades opheffen” from €135 to €160 to reflect the requested copy change.

### Description
- Changed `ENERGETISCHE_BLOKKADES_OPHEFFEN_HOMEPAGE_PRICE_CENTS` from `13500` to `16000` in `app/features/home/components/HomeTreatments.vue`, leaving descriptions and page structure unchanged.

### Testing
- Ran `git diff --check` (no issues) and `bun run build` (build succeeded); `bunx eslint app/features/home/components/HomeTreatments.vue` failed due to the repo ESLint config referencing `.nuxt/eslint.config.mjs`; an automated `playwright` screenshot was produced but API-driven treatment data failed to load in preview because Supabase server keys were not set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a8cb7c16083239c640707026fb37c)