### PR TITLE
fix: update qualifications copy

### DIFF
--- a/app/pages/over-mij.vue
+++ b/app/pages/over-mij.vue
@@ -20,22 +20,22 @@ const personSchema = {
   hasCredential: [
     {
       "@type": "EducationalOccupationalCredential",
-      name: "SoulKey Therapy Practitioner – SoulKey Academy (opgeleid door Peter Kupers)",
+      name: "Gecertificeerd SoulKey Therapy Practitioner – SoulKey Academy (opgeleid door Peter Kupers)",
       credentialCategory: "Professional Certification",
     },
     {
       "@type": "EducationalOccupationalCredential",
-      name: "Ericksoniaanse Hypnotherapie – UNLP Academie",
+      name: "Gecertificeerd Ericksoniaanse Hypnose – UNLP Academie",
       credentialCategory: "Professional Certification",
     },
     {
       "@type": "EducationalOccupationalCredential",
-      name: "Mindfulness MBSR Trainer – Centrum voor Mindfulness Amsterdam (opgeleid door drs. Rob Brandsma)",
+      name: "Gecertificeerd Mindfulness MBSR Trainer – Centrum voor Mindfulness Amsterdam (opgeleid door drs. Rob Brandsma)",
       credentialCategory: "Professional Certification",
     },
     {
       "@type": "EducationalOccupationalCredential",
-      name: "Erkend Wellnessmasseur – Anand Opleidingen",
+      name: "Gediplomeerd Erkend Wellnessmasseur – Anand Opleidingen",
       credentialCategory: "Professional Certification",
     },
   ],
@@ -195,8 +195,8 @@ setPageSEO({
                   class="w-5 h-5 text-green-500 mt-0.5"
                 />
                 <span class="text-neutral-600"
-                  >SoulKey Therapy Practitioner – SoulKey Academy (opgeleid door
-                  Peter Kupers)</span
+                  >Gecertificeerd SoulKey Therapy Practitioner – SoulKey Academy
+                  (opgeleid door Peter Kupers)</span
                 >
               </li>
               <li class="flex items-start gap-3">
@@ -205,7 +205,7 @@ setPageSEO({
                   class="w-5 h-5 text-green-500 mt-0.5"
                 />
                 <span class="text-neutral-600"
-                  >Ericksoniaanse Hypnotherapie – UNLP Academie</span
+                  >Gecertificeerd Ericksoniaanse Hypnose – UNLP Academie</span
                 >
               </li>
               <li class="flex items-start gap-3">
@@ -214,8 +214,8 @@ setPageSEO({
                   class="w-5 h-5 text-green-500 mt-0.5"
                 />
                 <span class="text-neutral-600"
-                  >Mindfulness MBSR Trainer – Centrum voor Mindfulness Amsterdam
-                  (opgeleid door drs. Rob Brandsma)</span
+                  >Gecertificeerd Mindfulness MBSR Trainer – Centrum voor Mindfulness
+                  Amsterdam (opgeleid door drs. Rob Brandsma)</span
                 >
               </li>
               <li class="flex items-start gap-3">
@@ -224,7 +224,7 @@ setPageSEO({
                   class="w-5 h-5 text-green-500 mt-0.5"
                 />
                 <span class="text-neutral-600"
-                  >Erkend Wellnessmasseur – Anand Opleidingen</span
+                  >Gediplomeerd Erkend Wellnessmasseur – Anand Opleidingen</span
                 >
               </li>
             </ul>


### PR DESCRIPTION
### Motivation
- De kwalificaties op de pagina moesten aangepast worden naar de aangeleverde formuleringen en hetzelfde moeten uitschrijven in de zichtbare lijst en in de Person structured data voor SEO-consistentie.

### Description
- Bewerkt `app/pages/over-mij.vue` en vervangen van de vier kwalificatieteksten in zowel het `hasCredential` schema als de zichtbare `Kwalificaties`-lijst.  
- Alleen tekstuele veranderingen doorgevoerd; de markup, componentstructuur en layout zijn ongewijzigd.  
- Zorg gedragen dat zichtbare content en SEO/structured data elkaar exact blijven weerspiegelen.

### Testing
- `bun run build` is uitgevoerd en de productiebuild voltooide succesvol met alleen bestaande omgevings- en externe-font-waarschuwingen.  
- Een content-assertiescript controleerde dat alle vier nieuwe labels aanwezig zijn in zowel de zichtbare content als in de structured data en dat de oude formuleringen afwezig zijn.  
- `bunx eslint app/pages/over-mij.vue` kon niet worden uitgevoerd vanwege een configuratie-importfout (`eslint.config.mjs` verwijst naar `.nuxt/eslint.config.mjs` als een ongeldige bare module), waardoor linting niet is afgerond.  
- Een poging om een UI-screenshot met `bunx playwright` te maken mislukte doordat de preview server request fouten gaf door ontbrekende Supabase-omgeving variabelen en ontbrekende systeembibliotheken, dus geen geldige screenshot kon worden geleverd.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b00d02f488323ab49944ab1d7c05f)