### PR TITLE
fix(content): update tweede sessie beschrijving

### DIFF
--- a/content/behandelingen/energetische-blokkades-opheffen.md
+++ b/content/behandelingen/energetische-blokkades-opheffen.md
@@ -75,7 +75,7 @@ Het kan ook gaan om herinneringen uit je kindertijd. Dat hoeven geen slechte her
 De eerste sessie combineert een geleide meditatie met chakra healing. Deze combinatie helpt bij het herkennen en losmaken van blokkades. Je leert contact maken met jezelf op een diepere laag en voelt waar energie vastzit.
 
 #### Sessie 2: Meditatie en Healing voor Diepere Verwerking (120 minuten - €160)
-In de tweede sessie gaan we dieper in op wat er in de eerste sessie is losgekomen. Met meditatie en healing werk je aan het verwerken van oude pijn en patronen. Deze sessie is gericht op acceptatie en vergeving.
+In de tweede sessie gaan we dieper in op wat er in de eerste sessie is losgekomen. Met meditatie en healing werk je aan het verwerken van oude pijn en patronen, waarbij we ons specifiek richten op het helen van het innerlijke kind. Deze sessie is volledig gericht op acceptatie en innerlijke rust.
 
 #### Sessie 3: Meditaties met Healing ter Integratie (120 minuten - €160)
 De derde sessie bestaat uit twee meditaties gecombineerd met healing. Dit geeft je de ruimte om het proces te integreren en alles wat is losgekomen een plek te geven. We ronden het traject af en zorgen dat alle energieën weer in balans zijn.


### PR DESCRIPTION
### Motivation
- Werk de tekst van "Sessie 2: Meditatie en Healing voor Diepere Verwerking" bij om expliciet het helen van het innerlijke kind te noemen en de focus te verleggen naar acceptatie en innerlijke rust.

### Description
- Vervangen van één zin in `content/behandelingen/energetische-blokkades-opheffen.md` met de aangeleverde tekst zonder frontmatter- of structuurwijzigingen (sectie en componentopmaak ongewijzigd).

### Testing
- Automatische validatie uitgevoerd via een Python-check op exacte vervanging, `git diff --check` uitgevoerd en `bun run build` gestart, waarbij de productiebuild succesvol afrondde (enkel bestaande waarschuwingen over ontbrekende externe config/fontproviders en componentnamen gemeld).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b11cf46d8832384444bfa407a2eb7)