### PR TITLE
fix: update hypnotherapy content

### DIFF
--- a/content/behandelingen/hypnotherapie.md
+++ b/content/behandelingen/hypnotherapie.md
@@ -1,6 +1,6 @@
 ---
 title: Hypnotherapie Trajecten
-description: Mijn unieke Hypno/Healing methode combineert diepgaande hypnotherapie met energetische (chakra) healing in Amsterdam Noord voor snelle én duurzame transformatie op lichaams-, geest- én zielsniveau.
+description: Ericksoniaanse hypnotherapie in Amsterdam Noord voor diepe ontspanning, inzicht in onbewuste patronen en persoonlijke begeleiding in jouw tempo.
 ---
 
 ::behandeling-hero
@@ -14,17 +14,15 @@ id: dd01fafe-5591-4ca2-b460-c18388237f76
 
 ::behandeling-sectie
 ---
-items:
-  - Snelle én duurzame resultaten door diepe doorwerking
-  - Minder sessies nodig door combinatie van hypnotherapie en energetische
-    healing
-  - Transformatie op lichaams-, geest- én zielsniveau
-  - Meer innerlijke rust, vertrouwen en levensenergie
 image: /images/single-sessions-hypnotherapie.webp
 imageAlt: Hypnotherapie en healing voor transformatie
-title: Mijn unieke Hypno/Healing methode
+title: De kracht van Ericksoniaanse hypnose
 ---
-Mijn manier van werken in mijn praktijk in Amsterdam Noord gaat verder dan standaard hypnotherapie. Ware verandering ontstaat niet aan de oppervlakte — maar diep van binnen: in het onderbewuste, in het lichaam en in jouw energetisch systeem. Door de unieke combinatie van hypnotherapie en energetische (chakra) healing vindt heling niet alleen mentaal en emotioneel plaats, maar ook op energetisch en zielsniveau.
+Hypnotherapie richt zich op het onderbewuste. Veel van onze gedachten, overtuigingen, emoties en automatische reacties ontstaan buiten ons bewuste denken. Hierdoor kunnen bepaalde patronen zich blijven herhalen, ook wanneer je bewust graag iets wilt veranderen.
+
+Met behulp van Ericksoniaanse hypnose begeleid ik je naar een diepe staat van ontspanning en gerichte aandacht. In deze toestand ontstaat ruimte om onbewuste patronen, overtuigingen en emotionele reacties te onderzoeken en meer inzicht te krijgen in wat jou mogelijk belemmert.
+
+In mijn praktijk in Amsterdam Noord werk ik met een rustige, persoonlijke en respectvolle benadering. Iedere sessie wordt afgestemd op jouw situatie, jouw hulpvraag en jouw tempo.
 ::
 
 ::twee-kolommen


### PR DESCRIPTION
### Motivation
- Vervang de bestaande sectie "Mijn unieke Hypno/Healing methode" door de doorgegeven tekst over Ericksoniaanse hypnose zodat de pagina inhoudelijk beter aansluit op de aangeboden werkwijze.
- Zorg dat de paginameta (`description`) de nieuwe focus op Ericksoniaanse hypnose reflecteert.

### Description
- Gewijzigd bestand: `content/behandelingen/hypnotherapie.md` waarin de `::behandeling-sectie` is bijgewerkt naar de titel `De kracht van Ericksoniaanse hypnose` en de nieuwe beschrijvende tekst is geplaatst.
- De oude bulletlijst met voordelen uit die sectie is verwijderd, terwijl de `image` en `imageAlt` velden en de pagina-structuur intact zijn gebleven.
- De frontmatter `description` is aangepast naar een kortere, op Ericksoniaanse hypnose gerichte meta-omschrijving.
- Er zijn geen wijzigingen gemaakt aan andere pagina's, componenten of routing, en het bestaande `::behandeling-hero` `id` is ongewijzigd.

### Testing
- Gecontroleerd met `rg`/`ripgrep` dat de nieuwe kop `De kracht van Ericksoniaanse hypnose` aanwezig is en de oude kop/tekst niet langer voorkomt in `content/behandelingen/hypnotherapie.md`.
- Gecontroleerd dat het gerelateerde `image`-veld ongewijzigd blijft met een visuele padreferentie in `content/behandelingen/hypnotherapie.md`.
- Proef-build met `bun run build` kon niet worden uitgevoerd in deze omgeving omdat dependencies niet zijn geïnstalleerd (`nuxt: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a316820e9fc83238e07165d9115d24d)