### PR TITLE
fix: update hypnotherapy chakra healing offer

### DIFF
--- a/app/components/content/TrajectKolommen.vue
+++ b/app/components/content/TrajectKolommen.vue
@@ -9,6 +9,9 @@ interface TrajectContentItem {
   ctaText?: string;
   ctaLink?: string;
   treatmentId?: string;
+  sessions?: number;
+  price_cents?: number;
+  duration_minutes?: number;
 }
 
 interface TrajectRecord {
@@ -108,9 +111,10 @@ const mergedTrajects = computed<TrajectDisplayItem[]>(() =>
       : undefined;
     return {
       ...item,
-      sessions: meta?.sessions,
-      price_cents: meta?.price_cents ?? treatmentMeta?.price_cents,
-      duration_minutes: treatmentMeta?.duration_minutes,
+      sessions: item.sessions ?? meta?.sessions,
+      price_cents:
+        item.price_cents ?? meta?.price_cents ?? treatmentMeta?.price_cents,
+      duration_minutes: item.duration_minutes ?? treatmentMeta?.duration_minutes,
     };
   })
 );

--- a/content/behandelingen/hypnotherapie.md
+++ b/content/behandelingen/hypnotherapie.md
@@ -71,12 +71,14 @@ items:
     ctaText: Plan losse sessie
     ctaLink: https://enisa-healing-massage.setmore.com
   - id: "41499119-22df-42a9-916a-ac32120f6d5b"
-    title: Hypnomeditatie
-    description: Een zachte en veilige methode om positieve verandering van binnenuit te ondersteunen — zonder aanraking of fysieke behandeling.
+    title: Hypnotherapie & Chakra Healing
+    description: Een uitgebreide sessie waarin ik de kracht van hypnotherapie combineer met chakra healing. Deze combinatie kan waardevol zijn wanneer mentale patronen en emotionele belasting met elkaar verbonden zijn en je behoefte hebt aan een bredere, holistische benadering.
+    sessions: 1
+    price_cents: 22900
     bullets:
-      - "Duur: 1u 15 min per sessie"
-      - Intake inbegrepen (30 min via telefoon of video)
-      - Gericht op rust, inzicht en positieve verandering
+      - "Duur: 150 minuten"
+      - Inclusief gratis kennismakings- en intakegesprek (30 minuten via WhatsApp met of zonder video)
+      - Gericht op inzicht, emotionele verwerking en een diepere verbinding tussen hoofd, gevoel en energie
     ctaText: Plan je intake
     ctaLink: https://enisa-healing-massage.setmore.com
   - id: "63f29db0-2b00-48e1-98dc-ed055bccfbf0"


### PR DESCRIPTION
### Motivation
- Update the Hypnotherapy treatment page to reflect a new single-session offering with refreshed copy, duration and price metadata.
- Ensure the content-driven traject card can display session/price/duration values provided directly in CMS content when applicable.

### Description
- Replaced the `traject-kolommen` entry in `content/behandelingen/hypnotherapie.md` to change the card title to `Hypnotherapie & Chakra Healing` and updated its description, `sessions: 1`, `price_cents: 22900`, duration bullet and intake/goal copy.
- Extended the `TrajectContentItem` interface in `app/components/content/TrajectKolommen.vue` to accept `sessions`, `price_cents` and `duration_minutes` from content.
- Adjusted the merge logic in `TrajectKolommen.vue` so content-provided `sessions`, `price_cents` and `duration_minutes` override fetched traject/treatment metadata when present.

### Testing
- Ran `bun install` which completed successfully. 
- Ran `bunx eslint app/components/content/TrajectKolommen.vue` which failed due to an ESLint config resolution issue importing `.nuxt/eslint.config.mjs` (existing repo config), not caused by the code changes.
- Ran `bun run build` which completed successfully and the production build artifacts were generated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a316fe4edb4832398028adccf8905b6)