### PR TITLE
fix: update Hypnotherapie session content

### DIFF
--- a/content/behandelingen/hypnotherapie.md
+++ b/content/behandelingen/hypnotherapie.md
@@ -61,13 +61,15 @@ In mijn praktijk in Amsterdam Noord werk ik met een rustige, persoonlijke en res
 ---
 items:
   - id: "c8ad40a0-7c7f-47a3-b6c4-2b3f1a6a7d3b"
-    title: Losse sessie hypnomeditatie
-    description: Een losse hypnomeditatie sessie voor wie eerst wil kennismaken of een gerichte vraag heeft.
+    title: Hypnotherapie
+    description: Een persoonlijke sessie met Ericksoniaanse hypnose om inzicht te krijgen in terugkerende patronen, beperkende overtuigingen en onbewuste processen die invloed hebben op jouw dagelijks leven.
     treatmentId: dd01fafe-5591-4ca2-b460-c18388237f76
+    sessions: 1
+    price_cents: 15500
     bullets:
-      - "Duur: 1u 15 min per sessie"
-      - Persoonlijke begeleiding afgestemd op jouw thema
-      - Ruimte voor rust, inzicht en ontspanning
+      - "Duur: 90 minuten"
+      - Inclusief gratis kennismakings- en intakegesprek (30 minuten via WhatsApp met of zonder video)
+      - Gericht op inzicht, persoonlijke groei en positieve verandering vanuit het onderbewuste
     ctaText: Plan losse sessie
     ctaLink: https://enisa-healing-massage.setmore.com
   - id: "41499119-22df-42a9-916a-ac32120f6d5b"


### PR DESCRIPTION
### Motivation
- Replace the old "Losse sessie hypnomeditatie" offer with the new `Hypnotherapie` copy to reflect the updated service description and intake details.
- Update session metadata to represent a single 90-minute session with pricing and intake information.
- Keep the existing page structure and database-linked `treatmentId` intact while only changing the content block.

### Description
- Updated `content/behandelingen/hypnotherapie.md` in the `::traject-kolommen` item with id `c8ad40a0-7c7f-47a3-b6c4-2b3f1a6a7d3b`. 
- Replaced `title` with `Hypnotherapie` and replaced the `description` with the provided Ericksonian hypnose copy. 
- Added `sessions: 1` and `price_cents: 15500`, and replaced the bullets with `Duur: 90 minuten`, the free 30-minute intake note, and the new focus sentence; `treatmentId`, `ctaText`, and `ctaLink` were preserved. 
- Changes were committed with message `fix: update hypnotherapy session content`.

### Testing
- ✅ Ran a Python content verification that asserts new strings exist and old strings were removed, which passed. 
- ✅ Ran `git diff --check` and basic Git status checks, which passed and the change was committed. 
- ⚠️ Attempted `bun run build` (runs `nuxt build`) but it failed in this environment because `nuxt` is not installed (`nuxt: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a317587317c8323aa9c7f1271bcfe2b)