### PR TITLE
fix: update hypnotherapie audience copy

### DIFF
--- a/content/behandelingen/hypnotherapie.md
+++ b/content/behandelingen/hypnotherapie.md
@@ -45,13 +45,14 @@ In mijn praktijk in Amsterdam Noord werk ik met een rustige, persoonlijke en res
   :::voor-wie
   ---
   items:
-    - Je oude patronen, angst of blokkades wilt loslaten
-    - Je emotionele lasten voelt die je wilt transformeren
-    - Je opnieuw verbinding wilt maken met rust en kracht
-    - Je klaar bent voor duurzame verandering van binnenuit
-    - Je een dieper ontwaken wilt ervaren
-    - Je zoekt naar innerlijke helderheid en stabiliteit
-    - Je wilt terugkeren naar wie je werkelijk bent
+    - Je last hebt van angst, stress of onzekerheid
+    - Je steeds terugvalt in dezelfde patronen
+    - Je negatieve overtuigingen wilt doorbreken
+    - Je meer zelfvertrouwen wilt ontwikkelen
+    - Je minder wilt piekeren en meer rust wilt ervaren
+    - Je beter wilt omgaan met emoties en reacties
+    - Je openstaat voor verandering vanuit het onderbewuste
+    - Je klaar bent voor persoonlijke groei en positieve verandering
   title: Voor Wie?
   ---
   :::


### PR DESCRIPTION
### Motivation
- Update the “Voor Wie?” audience bullet list on the Hypnotherapie treatment page to the provided, clearer phrasing while keeping the page structure and identifiers unchanged.

### Description
- Replaced the `voor-wie` items list in `content/behandelingen/hypnotherapie.md` with the new provided bullets and kept all other content blocks and metadata intact.

### Testing
- Ran `git diff --check`, inspected the updated lines with `nl -ba content/behandelingen/hypnotherapie.md | sed -n '43,60p'`, and verified `git status --short`, and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a318013d55483239f8a8fead9c1d2e7)