### PR TITLE
fix: update hypnotherapy intake heading

### DIFF
--- a/content/behandelingen/hypnotherapie.md
+++ b/content/behandelingen/hypnotherapie.md
@@ -122,7 +122,7 @@ items:
 ::
 
 
-::uitklap-info{title="Intake & voorbereiding"}
+::uitklap-info{title="Gratis kennismakings- en intakegesprek"}
 Vooraf plannen we een telefonisch intakegesprek van 30 minuten. Op basis van jouw thema's en intentie maak ik een persoonlijke hypnomeditatie, afgestemd op jouw proces en energie, zodat je tijdens de sessie sneller en dieper kunt loslaten.
 
 **Voel je dat dit het moment is? Plan je intakegesprek.**


### PR DESCRIPTION
### Motivation
- De sectietitel van de hypnotherapie-pagina moest worden aangepast om de nieuwe copy te tonen in het uitklap-accordeon.

### Description
- Vervangen van de uitklap-info titel in `content/behandelingen/hypnotherapie.md` van `Intake & voorbereiding` naar `Gratis kennismakings- en intakegesprek`.

### Testing
- Uitgevoerd: `rg -n 'uitklap-info\{title="(Intake & voorbereiding|Gratis kennismakings- en intakegesprek)"\}' content/behandelingen/hypnotherapie.md` en `git diff --check` (succeeded), wijziging gecommit, en `bun run build` gestart — Nuxt client/server build en Nitro prerendering voltooiden maar de buildproces was voorzien van omgevingswaarschuwingen en werd na de Nitro-build handmatig beëindigd.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3189ceaffc832386e134733b1abdbb)