### PR TITLE
fix: update hypnotherapy intake copy

### DIFF
--- a/content/behandelingen/hypnotherapie.md
+++ b/content/behandelingen/hypnotherapie.md
@@ -123,16 +123,23 @@ items:
 
 
 ::uitklap-info{title="Gratis kennismakings- en intakegesprek"}
-Vooraf plannen we een telefonisch intakegesprek van 30 minuten. Op basis van jouw thema's en intentie maak ik een persoonlijke hypnomeditatie, afgestemd op jouw proces en energie, zodat je tijdens de sessie sneller en dieper kunt loslaten.
+Vooraf plannen we een gratis kennismakings- en intakegesprek van 30 minuten via WhatsApp (met of zonder video).
 
-**Voel je dat dit het moment is? Plan je intakegesprek.**
-Bel of app: 06-22445121
+Tijdens dit gesprek bespreken we jouw hulpvraag, wensen en doelen. Samen kijken we welke sessie het beste aansluit bij jouw situatie en wat je kunt verwachten van de begeleiding.
+
+Dit gesprek geeft je de mogelijkheid om vragen te stellen en rustig kennis te maken voordat we de sessie inplannen.
+
+**Voel je dat dit het juiste moment is?**
+
+Plan eenvoudig online jouw gratis kennismakingsgesprek via de agenda op deze website.
+
+Of neem contact met mij op via:
+
+Telefoon / WhatsApp: 06-22445121
 
 ### Annulerings- & betalingsvoorwaarden
 
-- Bij annulering binnen 48 uur wordt de eerste termijn niet terugbetaald
-- De tweede sessie vindt plaats na betaling van de tweede termijn
-- Betalen via overmaken of Tikkie
+Bij annulering binnen 48 uur voor de afspraak ben ik genoodzaakt de gereserveerde tijd in rekening te brengen.
 ::
 
 ::uitklap-info{title="Meer over hypnotherapie"}


### PR DESCRIPTION
### Motivation
- Update the intake section to reflect a free 30-minute WhatsApp kennismakings- en intakegesprek (met of zonder video), clarify what is discussed, add online scheduling and update the cancellation wording.

### Description
- Replaced the `::uitklap-info{title="Gratis kennismakings- en intakegesprek"}` block in `content/behandelingen/hypnotherapie.md` with the new WhatsApp/online scheduling copy and contact number.
- Removed the previous telephone-only phrasing and the older multi-line payment/cancellation details and replaced them with the single updated cancellation sentence inside the same collapsible block.
- This is a content-only change and does not modify UI components, routes, environment variables, or data migrations.
- Existing frontmatter and the hero `id` were preserved.

### Testing
- Ran `git diff --check` which reported no issues.  
- Verified repository status with `git status --short` to confirm the file change was staged and committed.  
- Attempted `bunx eslint content/behandelingen/hypnotherapie.md` but the lint run failed due to a missing/generated Nuxt ESLint config at `.nuxt/eslint.config.mjs`, so a lint pass could not be completed.  
- No automated test suite is configured for this repository and no new tests were added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a318dfd155883238d47e3d79a09d5d1)