### PR TITLE
fix: update Hypnotherapie homepage price to €155

### DIFF
--- a/app/features/home/components/HomeTreatments.vue
+++ b/app/features/home/components/HomeTreatments.vue
@@ -100,7 +100,7 @@ const HYPNOTHERAPIE_HOMEPAGE_DESCRIPTION =
 const ANTI_STRESS_HOMEPAGE_DESCRIPTION =
   'In deze sessies leer je om bewust aanwezig te zijn in het hier en nu. Waardoor je meer rust en tevredenheid zult ervaren en meer vertrouwen zult krijgen in jezelf en de toekomst.';
 
-const HYPNOTHERAPIE_HOMEPAGE_PRICE_CENTS = 13000;
+const HYPNOTHERAPIE_HOMEPAGE_PRICE_CENTS = 15500;
 const ENERGETISCHE_BLOKKADES_OPHEFFEN_HOMEPAGE_PRICE_CENTS = 16000;
 
 const displayedTreatments = computed(() =>


### PR DESCRIPTION
### Motivation
- Update the displayed homepage price for the Hypnotherapie card from €130 to €155 to reflect the requested price change.

### Description
- Changed the value of `HYPNOTHERAPIE_HOMEPAGE_PRICE_CENTS` in `app/features/home/components/HomeTreatments.vue` from `13000` to `15500`.
- The change is applied via the existing `displayedTreatments` override that sets the `price` for the Hypnotherapie card, with no layout or component changes.

### Testing
- Verified the code change with `rg -n "HYPNOTHERAPIE_HOMEPAGE_PRICE_CENTS" app/features/home/components/HomeTreatments.vue` and inspected the file. ✅
- Ran `bun install` successfully. ✅
- Ran `bun run build`, which completed the Nuxt/Nitro build but emitted warnings about missing Supabase environment variables and external font-provider fetch failures. ⚠️
- Started the local dev server with `bun run dev` and fetched the homepage via `curl http://127.0.0.1:3000/` which succeeded, noting the static HTML may not contain the textual price because the price is rendered client-side. ✅

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3193847ce08323ad763a7cc82143ae)