### PR TITLE
fix: update homepage hypnotherapy copy

### DIFF
--- a/app/features/home/components/HomeTreatments.vue
+++ b/app/features/home/components/HomeTreatments.vue
@@ -95,7 +95,7 @@ const contentDescriptionsBySlug = computed(() => {
 });
 
 const HYPNOTHERAPIE_HOMEPAGE_DESCRIPTION =
-  'Waar echte transformatie begint. Combinatie van hypnotherapie en energetische healing voor duurzame verandering op mentaal, emotioneel en energetisch niveau.';
+  'Met behulp van Ericksoniaanse hypnose begeleid ik je in Amsterdam Noord bij stress, angst, onzekerheid, het versterken van zelfvertrouwen en het doorbreken van terugkerende patronen. Ook mogelijk in combinatie met chakra healing.';
 
 const ANTI_STRESS_HOMEPAGE_DESCRIPTION =
   'In deze sessies leer je om bewust aanwezig te zijn in het hier en nu. Waardoor je meer rust en tevredenheid zult ervaren en meer vertrouwen zult krijgen in jezelf en de toekomst.';


### PR DESCRIPTION
### Motivation
- Update de korte beschrijving van de Hypnotherapie-sectie op de homepage zodat deze de gewenste Ericksoniaanse-hypnose copy en vermelding van chakra healing weergeeft.

### Description
- Vervangen van de constante `HYPNOTHERAPIE_HOMEPAGE_DESCRIPTION` in `app/features/home/components/HomeTreatments.vue` met de nieuwe Nederlandse tekst over Ericksoniaanse hypnose en de combinatie met chakra healing.

### Testing
- Uitgevoerd `bun install` (geslaagd), `bun run build` (geslaagd met bestaande environment/font-waarschuwingen), en geverifieerd dat de nieuwe tekst aanwezig is in de bron en in de gegenereerde build met `rg -n "Met behulp van Ericksoniaanse|Waar echte transformatie"` (geslaagd).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31992f91c4832397828ac2ee2eea26)