### PR TITLE
fix: remove per-session pricing from Energetische blokkades content

### DIFF
--- a/content/behandelingen/energetische-blokkades-opheffen.md
+++ b/content/behandelingen/energetische-blokkades-opheffen.md
@@ -13,9 +13,9 @@ id: da84341d-d8cd-4db7-bacf-7d2495ecccb4
 ::behandeling-sectie
 ---
 items:
-  - "Sessie 1 (120 min): Meditatie gecombineerd met chakra healing - €160"
-  - "Sessie 2 (120 min): Meditatie en healing voor diepere verwerking - €160"
-  - "Sessie 3 (120 min): Twee meditaties om het proces te integreren met healing - €160"
+  - "Sessie 1 (120 min): Meditatie gecombineerd met chakra healing"
+  - "Sessie 2 (120 min): Meditatie en healing voor diepere verwerking"
+  - "Sessie 3 (120 min): Twee meditaties om het proces te integreren met healing"
   - "Traject: 3 sessies voor €480 (Losse sessies: €160 per sessie)"
 image: /images/loslaten-traject.webp
 imageAlt: Traject voor het opheffen van energetische blokkades in Amsterdam Noord


### PR DESCRIPTION
### Motivation
- Content update to match the provided replacement copy by removing the per-session „€160” suffix from the first three session bullets while keeping the trajectprijs intact.

### Description
- Updated `content/behandelingen/energetische-blokkades-opheffen.md` to remove `- €160` from the three session items in the `::behandeling-sectie` and kept the "Traject: 3 sessies voor €480 (Losse sessies: €160 per sessie)" line unchanged.

### Testing
- Ran a Python content check that asserts the old priced lines are absent and the new lines are present, and the check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33d79d34848323ac9b89ed1cf876ac)