### PR TITLE
fix: update 'Sessie 1' heading in energetische blokkades content

### DIFF
--- a/content/behandelingen/energetische-blokkades-opheffen.md
+++ b/content/behandelingen/energetische-blokkades-opheffen.md
@@ -71,7 +71,7 @@ Het kan ook gaan om herinneringen uit je kindertijd. Dat hoeven geen slechte her
 
 ### Sessie Opbouw
 
-#### Sessie 1: Meditatie met Chakra Healing (120 minuten - €160)
+#### Sessie 1: Meditatie met Chakra Healing
 De eerste sessie combineert een geleide meditatie met chakra healing. Deze combinatie helpt bij het herkennen en losmaken van blokkades. Je leert contact maken met jezelf op een diepere laag en voelt waar energie vastzit.
 
 #### Sessie 2: Meditatie en Healing voor Diepere Verwerking (120 minuten - €160)


### PR DESCRIPTION
### Motivation
- Remove the duration and price from the first session heading so the page matches the requested copy and remains consistent.

### Description
- Updated `content/behandelingen/energetische-blokkades-opheffen.md` by replacing `Sessie 1: Meditatie met Chakra Healing (120 minuten - €160)` with `Sessie 1: Meditatie met Chakra Healing`.

### Testing
- Ran `rg -n "Sessie 1: Meditatie met Chakra Healing|Sessie Opbouw" content/behandelingen/energetische-blokkades-opheffen.md`, `git diff --check`, and `git status --short`, and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33d8b89d0c8323a47ca64144dec831)