### PR TITLE
fix: remove duration/price from Sessie 2 heading in energetische-blokkades-opheffen

### DIFF
--- a/content/behandelingen/energetische-blokkades-opheffen.md
+++ b/content/behandelingen/energetische-blokkades-opheffen.md
@@ -74,7 +74,7 @@ Het kan ook gaan om herinneringen uit je kindertijd. Dat hoeven geen slechte her
 #### Sessie 1: Meditatie met Chakra Healing (120 minuten - €160)
 De eerste sessie combineert een geleide meditatie met chakra healing. Deze combinatie helpt bij het herkennen en losmaken van blokkades. Je leert contact maken met jezelf op een diepere laag en voelt waar energie vastzit.
 
-#### Sessie 2: Meditatie en Healing voor Diepere Verwerking (120 minuten - €160)
+#### Sessie 2: Meditatie en Healing voor Diepere Verwerking 
 In de tweede sessie gaan we dieper in op wat er in de eerste sessie is losgekomen. Met meditatie en healing werk je aan het verwerken van oude pijn en patronen, waarbij we ons specifiek richten op het helen van het innerlijke kind. Deze sessie is volledig gericht op acceptatie en innerlijke rust.
 
 #### Sessie 3: Meditaties met Healing ter Integratie (120 minuten - €160)


### PR DESCRIPTION
### Motivation
- Update the treatment content to remove the duration and price text from the Sessie 2 heading so the page matches the requested copy.

### Description
- Modified `content/behandelingen/energetische-blokkades-opheffen.md` to replace `#### Sessie 2: Meditatie en Healing voor Diepere Verwerking (120 minuten - €160)` with `#### Sessie 2: Meditatie en Healing voor Diepere Verwerking`.

### Testing
- Verified the update with `rg -n "Sessie 2: Meditatie en Healing voor Diepere Verwerking|120 minuten - €160" content/behandelingen/energetische-blokkades-opheffen.md` and inspected the change using `git diff -- content/behandelingen/energetische-blokkades-opheffen.md`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33db0b68ec832386ee6fbe3ee282f4)