### PR TITLE
fix: remove hypnotherapy trajectory packages

### DIFF
--- a/content/behandelingen/hypnotherapie.md
+++ b/content/behandelingen/hypnotherapie.md
@@ -1,5 +1,5 @@
 ---
-title: Hypnotherapie Trajecten
+title: Hypnotherapie
 description: Ericksoniaanse hypnotherapie in Amsterdam Noord voor diepe ontspanning, inzicht in onbewuste patronen en persoonlijke begeleiding in jouw tempo.
 ---
 
@@ -83,40 +83,6 @@ items:
       - Inclusief gratis kennismakings- en intakegesprek (30 minuten via WhatsApp met of zonder video)
       - Gericht op inzicht, emotionele verwerking en een diepere verbinding tussen hoofd, gevoel en energie
     ctaText: Plan je intake
-    ctaLink: https://enisa-healing-massage.setmore.com
-  - id: "63f29db0-2b00-48e1-98dc-ed055bccfbf0"
-    title: Transformatie traject
-    description: |
-      Voor mensen die voelen dat het tijd is om oude patronen, angst, blokkades en emotionele lasten los te laten — en opnieuw verbinding te maken met rust, kracht en innerlijke helderheid.
-
-      Betaling mogelijk in 2 termijnen:
-      €297,50 bij het maken van de afspraak
-      €297,50 vóór de tweede sessie
-    bullets:
-      - "Duur: 2u per sessie"
-      - Hypnotherapie + energetische/chakra healing
-      - 3 persoonlijke mini-rituelen
-      - 1 korte check-in tussen sessies
-    ctaText: Start jouw traject
-    ctaLink: https://enisa-healing-massage.setmore.com
-  - id: "bd93dfc2-df1e-4906-be98-7329e772c08d"
-    title: Premium traject
-    description: |
-      Een luxere, diepere en zachtere reis naar innerlijke transformatie met extra ondersteuning en rituelen.
-
-      Betaling mogelijk in 2 termijnen:
-      €388,50 bij het maken van de afspraak
-      en €388,50 vóór de tweede sessie.
-    bullets:
-      - "Duur: 2u per sessie"
-      - Hypnotherapie + energetische/chakra healing
-      - Integratie & nazorg
-      - Intuïtieve inzichten en begeleiding
-      - 1 hoofd/gezicht ontspanningsmassage
-      - 4 premium rituelen.
-      - 1 persoonlijke helende audio
-      - Korte WhatsApp ondersteuning
-    ctaText: Kies premium
     ctaLink: https://enisa-healing-massage.setmore.com
 ---
 ::


### PR DESCRIPTION
### Motivation
- De hypnotherapie-pagina bood meerdere trajecten maar de wens was om de twee trajectaanbiedingen volledig te verwijderen zodat alleen losse sessies overblijven. 
- De paginatitel moest worden aangepast van `Hypnotherapie Trajecten` naar `Hypnotherapie` om bij de nieuwe inhoud te passen.

### Description
- Verwijderd: de volledige items `Transformatie traject` en `Premium traject` uit de `::traject-kolommen` in `content/behandelingen/hypnotherapie.md` zodat alleen de losse sessie-opties behouden blijven. 
- Aangepast: de frontmatter `title` gewijzigd van `Hypnotherapie Trajecten` naar `Hypnotherapie` om de pagina-inhoud te laten overeenkomen met de resterende aanbiedingen. 
- Bestandswijziging beperkt tot `content/behandelingen/hypnotherapie.md` en conform de content-structuur van het project gebleven.

### Testing
- Gereproduceerd installatie met `bun install`, welke succesvol externe pakketten installeerde. 
- Productie-build uitgevoerd met `bun run build`, welke succesvol voltooid is met alleen configuratie- en provider-warnings (geen fouten die de build blokkeerden). 
- Validatie uitgevoerd met `rg`-zoekopdracht naar verwijzingen (`Transformatie traject|Premium traject|Hypnotherapie Trajecten`) in het bewerkte bestand en deze gaven geen resultaten terug.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33ec7010a08323825a097c3f5446cb)