### PR TITLE
fix: update Hypnotherapie & Chakra Healing homepage copy

### DIFF
--- a/app/features/home/components/HomeTreatments.vue
+++ b/app/features/home/components/HomeTreatments.vue
@@ -95,7 +95,7 @@ const contentDescriptionsBySlug = computed(() => {
 });
 
 const HYPNOTHERAPIE_HOMEPAGE_DESCRIPTION =
-  'Met behulp van Ericksoniaanse hypnose begeleid ik je in Amsterdam Noord bij stress, angst, onzekerheid, het versterken van zelfvertrouwen en het doorbreken van terugkerende patronen. Ook mogelijk in combinatie met chakra healing.';
+  'Een uitgebreide sessie waarin ik de kracht van hypnotherapie combineer met chakra healing. Deze combinatie kan waardevol zijn wanneer mentale patronen en emotionele belasting met elkaar verbonden zijn en je behoefte hebt aan een bredere, holistische benadering.';
 
 const ANTI_STRESS_HOMEPAGE_DESCRIPTION =
   'In deze sessies leer je om bewust aanwezig te zijn in het hier en nu. Waardoor je meer rust en tevredenheid zult ervaren en meer vertrouwen zult krijgen in jezelf en de toekomst.';


### PR DESCRIPTION
### Motivation
- Update the Hypnotherapie & Chakra Healing homepage copy so the site displays the new, provided Dutch description for the treatment section.

### Description
- Replace the `HYPNOTHERAPIE_HOMEPAGE_DESCRIPTION` string in `app/features/home/components/HomeTreatments.vue` with the new Dutch sentence provided.

### Testing
- Ran `rg -n "Een uitgebreide sessie waarin ik de kracht" app/features/home/components/HomeTreatments.vue` which found the new string, `git diff --check` showed no problems, `bun install` completed successfully and `bun run build` completed successfully; `bunx eslint app/features/home/components/HomeTreatments.vue` failed due to an environment-specific `eslint.config.mjs` import of `.nuxt/eslint.config.mjs`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34175696e08323bf7e9014a656a1d6)