### PR TITLE
feat: add SoulKey Therapy treatment

### DIFF
--- a/content/behandelingen/soulkey-therapy.md
+++ b/content/behandelingen/soulkey-therapy.md
@@ -1,0 +1,87 @@
+---
+title: SoulKey Therapy
+description: SoulKey Therapy in Amsterdam Noord helpt je om dieper contact te maken met jezelf, oude patronen te herkennen en meer rust, helderheid en vertrouwen te ervaren.
+---
+
+::behandeling-hero
+---
+description: SoulKey Therapy is een zachte, intuïtieve therapievorm waarin we
+  samen onderzoeken wat er op een dieper niveau in jou gezien, gevoeld en
+  losgelaten mag worden. De sessie ondersteunt je bij innerlijke rust,
+  bewustwording, emotionele balans en het versterken van vertrouwen in jezelf.
+id: 0ff30744-63e2-4996-a90a-2e35a15f631f
+---
+::
+
+::behandeling-sectie
+---
+items:
+  - Een rustige intake waarin jouw hulpvraag centraal staat
+  - Intuïtieve begeleiding afgestemd op wat jij op dat moment nodig hebt
+  - Ruimte om emoties, overtuigingen en terugkerende patronen te onderzoeken
+  - Ondersteuning bij het loslaten van spanning en innerlijke blokkades
+  - Meer bewustwording van jouw gevoel, grenzen en verlangens
+  - Praktische inzichten om na de sessie mee verder te gaan
+image: /images/buddha.webp
+imageAlt: Rustgevende ruimte voor SoulKey Therapy in Amsterdam Noord
+title: Wat kun je verwachten?
+---
+Tijdens een SoulKey Therapy sessie begeleid ik je op een rustige en persoonlijke manier naar meer contact met jezelf. We kijken naar wat er onder de oppervlakte speelt: gevoelens, overtuigingen, oude ervaringen of patronen die invloed hebben op hoe je je nu voelt.
+
+De behandeling is afgestemd op jouw tempo en jouw hulpvraag. Er hoeft niets geforceerd te worden. Door aandacht, intuïtie en een veilige setting ontstaat er ruimte om te voelen wat gezien mag worden en om stap voor stap meer helderheid, ontspanning en vertrouwen te ervaren.
+::
+
+::twee-kolommen
+  :::voordelen-lijst
+  ---
+  items:
+    - Meer innerlijke rust en helderheid
+    - Dieper contact met je gevoel en intuïtie
+    - Inzicht in terugkerende patronen
+    - Verzachten van emotionele spanning
+    - Meer vertrouwen in jezelf en je keuzes
+    - Beter voelen waar jouw grenzen liggen
+    - Ondersteuning bij persoonlijke groei
+    - Meer balans tussen hoofd, hart en lichaam
+  title: Belangrijkste Voordelen
+  ---
+  :::
+
+  :::voor-wie
+  ---
+  items:
+    - Je het gevoel hebt vast te lopen in jezelf
+    - Je terugkerende patronen wilt begrijpen
+    - Je behoefte hebt aan rust, richting of helderheid
+    - Je emoties beter wilt leren voelen en dragen
+    - Je meer vertrouwen wilt ontwikkelen
+    - Je moeite hebt met grenzen aangeven
+    - Je openstaat voor intuïtieve begeleiding
+    - Je klaar bent voor persoonlijke verdieping
+  title: Voor Wie?
+  ---
+  :::
+::
+
+::uitklap-info{title="Meer over SoulKey Therapy"}
+SoulKey Therapy richt zich op bewustwording, innerlijke verbinding en persoonlijke groei. Soms weet je met je hoofd wel wat je wilt veranderen, maar voelt het vanbinnen alsof iets je tegenhoudt. Tijdens een sessie onderzoeken we welke gevoelens, overtuigingen of ervaringen hierin een rol kunnen spelen.
+
+De begeleiding is zacht, respectvol en intuïtief. Ik stem af op jouw energie en op wat zich aandient in het moment. Dit kan helpen om oude spanning te verzachten, nieuwe inzichten te krijgen en meer ruimte te voelen om keuzes te maken die bij jou passen.
+
+### Mogelijke thema's
+
+SoulKey Therapy kan ondersteunend zijn bij:
+
+- Stress, onrust of overprikkeling
+- Onzekerheid of gebrek aan vertrouwen
+- Moeite met grenzen aangeven
+- Terugkerende emotionele patronen
+- Gevoelens van blokkade of vastlopen
+- Behoefte aan meer zelfinzicht
+- Persoonlijke of spirituele ontwikkeling
+- Het verlangen om dichter bij jezelf te komen
+
+### Belangrijk om te weten
+
+SoulKey Therapy is een complementaire vorm van begeleiding en vervangt geen medische of psychologische behandeling. Bij medische of psychische klachten adviseer ik altijd om ook contact te houden met je huisarts of behandelaar.
+::

--- a/supabase/migrations/20260619000000_add_soulkey_therapy_treatment.sql
+++ b/supabase/migrations/20260619000000_add_soulkey_therapy_treatment.sql
@@ -1,0 +1,31 @@
+-- Add SoulKey Therapy treatment metadata so the content page appears in dynamic menus.
+INSERT INTO treatments (
+  id,
+  name,
+  slug,
+  description,
+  duration_minutes,
+  price_cents,
+  icon,
+  is_active,
+  display_order
+) VALUES (
+  '0ff30744-63e2-4996-a90a-2e35a15f631f',
+  'SoulKey Therapy',
+  'soulkey-therapy',
+  'SoulKey Therapy in Amsterdam Noord helpt je om dieper contact te maken met jezelf, oude patronen te herkennen en meer rust, helderheid en vertrouwen te ervaren.',
+  90,
+  15500,
+  'i-mdi-key-variant',
+  true,
+  8
+)
+ON CONFLICT (slug) DO UPDATE SET
+  name = EXCLUDED.name,
+  description = EXCLUDED.description,
+  duration_minutes = EXCLUDED.duration_minutes,
+  price_cents = EXCLUDED.price_cents,
+  icon = EXCLUDED.icon,
+  is_active = EXCLUDED.is_active,
+  display_order = EXCLUDED.display_order,
+  updated_at = NOW();


### PR DESCRIPTION
### Motivation
- Add a missing treatment content page so the SoulKey Therapy link works from the treatments menu and the public site shows the new page.
- Ensure the dynamic navigation shows the page by adding the corresponding database metadata so the existing menu generation continues to work.

### Description
- Created a new content file `content/behandelingen/soulkey-therapy.md` with frontmatter, `::behandeling-hero` (including a preserved `id` UUID), expectation section, benefits/for-who columns and an expandable info block.
- Added a Supabase migration `supabase/migrations/20260619000000_add_soulkey_therapy_treatment.sql` that inserts/updates the `soulkey-therapy` treatment row (id, slug, name, description, duration, price, icon, `is_active`, `display_order`) so the dynamic menus and APIs include it.
- Changes were committed with the message `feat: add soulkey therapy treatment` and prepared as a PR.

### Testing
- Ran `bun install` which completed successfully.
- Ran `bunx eslint content/behandelingen/soulkey-therapy.md supabase/migrations/20260619000000_add_soulkey_therapy_treatment.sql` which failed due to an existing ESLint configuration/import issue referencing `.nuxt/eslint.config.mjs` and not due to the new files.
- Ran `bun run build` which completed successfully; the build emitted warnings about missing Supabase/Studio environment variables and remote font-provider fetch warnings but finished without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34f87874b08323ac0bfb1f32dcf20a)