### PR TITLE
fix: add SoulKey therapy treatment route

### DIFF
--- a/app/components/content/BehandelingHero.vue
+++ b/app/components/content/BehandelingHero.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { type Treatment } from '~/features/admin/types/treatment.types';
+import type { TreatmentData } from '~/composables/useTreatments';
 
 interface Props {
   // Content-based props (fallback)
@@ -8,6 +9,7 @@ interface Props {
 }
 
 const props = defineProps<Props>();
+const pageTreatmentData = inject<TreatmentData | null>('treatmentData', null);
 
 // Always fetch from database for SEO and consistency
 const { data: treatmentData } = await useFetch<Treatment>(
@@ -19,24 +21,48 @@ const { data: treatmentData } = await useFetch<Treatment>(
 );
 
 // Computed values that prioritize database data over content data
-const displayTitle = computed(() => treatmentData.value?.name);
-const displayPrice = computed(() => treatmentData.value?.price_cents);
-const displayDuration = computed(() => treatmentData.value?.duration_minutes);
-const displayIcon = computed(() => treatmentData.value?.icon);
-const displayDiscountEnabled = computed(() => treatmentData.value?.discount_enabled || false);
-const displayDiscountPrice = computed(() => treatmentData.value?.discount_price_cents);
-const displayTrajects = computed(() => treatmentData.value?.trajects || []);
-
+const displayTitle = computed(
+  () => treatmentData.value?.name || pageTreatmentData?.title
+);
+const displayPrice = computed(
+  () => treatmentData.value?.price_cents || pageTreatmentData?.price
+);
+const displayDuration = computed(
+  () => treatmentData.value?.duration_minutes || pageTreatmentData?.duration
+);
+const displayIcon = computed(
+  () => treatmentData.value?.icon || pageTreatmentData?.icon
+);
+const displayDiscountEnabled = computed(
+  () =>
+    treatmentData.value?.discount_enabled ||
+    pageTreatmentData?.discountEnabled ||
+    false
+);
+const displayDiscountPrice = computed(
+  () =>
+    treatmentData.value?.discount_price_cents || pageTreatmentData?.discountPrice
+);
+const displayTrajects = computed(
+  () => treatmentData.value?.trajects || pageTreatmentData?.trajects || []
+);
 </script>
 
 <template>
-  <section class="not-prose bg-gradient-to-b from-secondary-200 to-primary-50 py-12 sm:py-16">
+  <section
+    class="not-prose bg-gradient-to-b from-secondary-200 to-primary-50 py-12 sm:py-16"
+  >
     <UContainer v-if="displayTitle">
-        <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 lg:gap-10 items-start">
-          <!-- Title Section -->
-          <div class="lg:col-span-2">
-            <div class="flex items-center gap-3 mb-6">
-            <UIcon v-if="displayIcon" :name="displayIcon" class="w-8 h-8 text-primary-600" aria-hidden="true" />
+      <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 lg:gap-10 items-start">
+        <!-- Title Section -->
+        <div class="lg:col-span-2">
+          <div class="flex items-center gap-3 mb-6">
+            <UIcon
+              v-if="displayIcon"
+              :name="displayIcon"
+              class="w-8 h-8 text-primary-600"
+              aria-hidden="true"
+            />
             <h1 class="text-4xl sm:text-5xl lg:text-6xl font-bold text-neutral-900">
               {{ displayTitle }}
             </h1>

--- a/app/features/treatments/TreatmentPage.vue
+++ b/app/features/treatments/TreatmentPage.vue
@@ -3,7 +3,8 @@ import type { TreatmentsCollectionItem } from '@nuxt/content';
 
 interface TreatmentData {
   id: string;
-  name: string;
+  name?: string;
+  title?: string;
   slug: string;
   description?: string;
   duration_minutes: number;
@@ -43,7 +44,10 @@ interface StructuredDataItem {
 if (props.treatment || props.treatmentData) {
   // Use database data when available, fall back to content data
   const title =
-    props.treatmentData?.name || props.treatment?.title || 'Treatment';
+    props.treatmentData?.name ||
+    props.treatmentData?.title ||
+    props.treatment?.title ||
+    'Treatment';
   const description = props.treatment?.description || '';
   const price =
     props.treatmentData?.price_formatted ||
@@ -136,7 +140,11 @@ const breadcrumbs = computed(() => [
     path: `/behandelingen/${
       props.treatmentData?.slug || props.treatment?.path || ''
     }`,
-    label: props.treatmentData?.name || props.treatment?.title || 'Behandeling',
+    label:
+      props.treatmentData?.name ||
+      props.treatmentData?.title ||
+      props.treatment?.title ||
+      'Behandeling',
     icon: 'i-mdi-sparkles',
   },
 ]);
@@ -191,14 +199,16 @@ const breadcrumbs = computed(() => [
     <div v-else-if="treatmentData" class="py-16">
       <UContainer>
         <div class="max-w-4xl mx-auto prose prose-lg">
-          <h2>{{ treatmentData.name }}</h2>
+          <h2>{{ treatmentData.name || treatmentData.title }}</h2>
           <p>Meer details over deze behandeling zijn binnenkort beschikbaar.</p>
         </div>
       </UContainer>
     </div>
 
     <!-- Call-to-Action Section -->
-    <TreatmentCTA :treatment="treatment || { title: treatmentData?.name }" />
+    <TreatmentCTA
+      :treatment="treatment || { title: treatmentData?.name || treatmentData?.title }"
+    />
 
     <!-- Related Treatments -->
     <RelatedTreatments />

--- a/content/behandelingen/regressietherapie-soulkey-therapy.md
+++ b/content/behandelingen/regressietherapie-soulkey-therapy.md
@@ -1,0 +1,59 @@
+---
+title: Regressietherapie & SoulKey Therapy
+description: Regressietherapie en SoulKey Therapy in Amsterdam Noord voor inzicht, bewustwording en het verzachten van terugkerende patronen.
+---
+
+::behandeling-hero
+---
+description: Regressietherapie en SoulKey Therapy helpen je om terugkerende patronen, emoties en blokkades beter te begrijpen. In een veilige en persoonlijke sessie onderzoek je wat op een diepere laag aandacht vraagt, zodat er meer rust, helderheid en ruimte kan ontstaan.
+---
+::
+
+::behandeling-sectie
+---
+title: Inzicht in terugkerende patronen
+---
+Soms reageer je op situaties op een manier die je verstandelijk wel begrijpt, maar toch moeilijk kunt veranderen. Regressietherapie en SoulKey Therapy richten zich op de diepere lagen achter zulke reacties, gevoelens en overtuigingen.
+
+Tijdens de sessie begeleid ik je op een rustige en respectvolle manier naar meer inzicht in wat er onder de oppervlakte speelt. Je blijft aanwezig en bewust, terwijl we samen onderzoeken welke ervaringen, emoties of overtuigingen mogelijk nog invloed hebben op jouw dagelijks leven.
+
+Deze behandeling is bedoeld als ondersteuning bij persoonlijke groei, bewustwording en het verzachten van emotionele of energetische blokkades.
+::
+
+::twee-kolommen
+  :::voordelen-lijst
+  ---
+  title: Wat je gaat merken
+  items:
+    - Meer inzicht in terugkerende patronen
+    - Meer rust in hoofd en lichaam
+    - Verzachting van oude emoties of blokkades
+    - Bewuster omgaan met reacties en keuzes
+    - Meer verbinding met jezelf
+    - Ruimte voor persoonlijke groei en verandering
+  ---
+  :::
+
+  :::voor-wie
+  ---
+  title: Voor Wie?
+  items:
+    - Je steeds tegen dezelfde thema's aanloopt
+    - Je oude emoties of overtuigingen wilt onderzoeken
+    - Je meer helderheid wilt over jezelf en je gedrag
+    - Je openstaat voor innerlijk onderzoek
+    - Je behoefte hebt aan een rustige, persoonlijke begeleiding
+    - Je voelt dat er op een diepere laag iets gezien mag worden
+  ---
+  :::
+::
+
+::uitklap-info{title="Hoe verloopt een sessie?"}
+We starten met een rustig gesprek over jouw hulpvraag en wat je graag wilt onderzoeken. Daarna begeleid ik je stap voor stap naar een ontspannen en geconcentreerde staat waarin er ruimte ontstaat om naar binnen te keren.
+
+Je hoeft niets te forceren. Alles gebeurt in jouw tempo en binnen wat voor jou veilig en passend voelt.
+::
+
+::uitklap-info{title="Belangrijk om te weten"}
+Regressietherapie en SoulKey Therapy zijn bedoeld als begeleiding bij bewustwording en persoonlijke ontwikkeling. De behandeling vervangt geen medische of psychologische zorg. Bij ernstige klachten of trauma adviseer ik om eerst contact op te nemen met een arts, psycholoog of andere gekwalificeerde zorgverlener.
+::


### PR DESCRIPTION
### Motivation
- Nuxt Content had no markdown file for the slug `/behandelingen/regressietherapie-soulkey-therapy`, causing the catch-all route to fall back to the homepage instead of rendering a treatment page. 
- The treatment rendering expected a `name` field while the database/composable format used `title`, so newly added content could be present but not displayed correctly.

### Description
- Added the content page `content/behandelingen/regressietherapie-soulkey-therapy.md` to expose the new route and provide the treatment content.
- Updated `app/features/treatments/TreatmentPage.vue` to accept `title` as an optional field and to use `props.treatmentData?.title` as a fallback in structured data, breadcrumbs, heading and CTA so database-shaped responses render correctly.
- Updated `app/components/content/BehandelingHero.vue` to `inject` page-level `treatmentData` and fall back to those fields when the database fetch by `id` is not present, making the hero robust for content-only pages.

### Testing
- Ran `bun install` successfully to install dependencies.
- Ran ESLint (`bunx eslint app/components/content/BehandelingHero.vue app/features/treatments/TreatmentPage.vue`) and it was blocked by an existing ESLint config import issue (`eslint.config.mjs` imports `.nuxt/eslint.config.mjs` as a package specifier).
- Ran the production build (`bun run build`) and Nuxt/Nitro reached the server build stage with logs showing `Nuxt Nitro server built` and prerendering of content; the process was later terminated manually while build output indicates the server build completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34fcde286483238eef2c2f050442d2)