### PR TITLE
feat: Add SoulKey Therapy content page, hero subtitle & accordion layout

### DIFF
--- a/app/components/content/BehandelingHero.vue
+++ b/app/components/content/BehandelingHero.vue
@@ -4,43 +4,79 @@ import { type Treatment } from '~/features/admin/types/treatment.types';
 interface Props {
   // Content-based props (fallback)
   id?: string;
+  title?: string;
+  subtitle?: string;
   description?: string;
 }
 
 const props = defineProps<Props>();
 
-// Always fetch from database for SEO and consistency
-const { data: treatmentData } = await useFetch<Treatment>(
-  `/api/treatments/${props.id}`,
-  {
-    // This will run server-side during SSR, making it SEO-friendly
+const isUuid = (value?: string) =>
+  Boolean(
+    value?.match(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    ),
+  );
+
+const injectedTreatmentData = inject<Ref<Treatment | null | undefined> | null>(
+  'treatmentData',
+  null,
+);
+
+let fetchedTreatmentData = ref<Treatment | null>(null);
+
+// Fetch from database for SEO and consistency when the content provides a UUID.
+if (isUuid(props.id)) {
+  const { data } = await useFetch<Treatment>(`/api/treatments/${props.id}`, {
     server: true,
-  }
+  });
+
+  fetchedTreatmentData = data;
+}
+
+const treatmentData = computed(
+  () => fetchedTreatmentData.value || injectedTreatmentData?.value || null,
 );
 
 // Computed values that prioritize database data over content data
-const displayTitle = computed(() => treatmentData.value?.name);
+const displayTitle = computed(() => props.title || treatmentData.value?.name);
 const displayPrice = computed(() => treatmentData.value?.price_cents);
 const displayDuration = computed(() => treatmentData.value?.duration_minutes);
 const displayIcon = computed(() => treatmentData.value?.icon);
-const displayDiscountEnabled = computed(() => treatmentData.value?.discount_enabled || false);
-const displayDiscountPrice = computed(() => treatmentData.value?.discount_price_cents);
+const displayDiscountEnabled = computed(
+  () => treatmentData.value?.discount_enabled || false,
+);
+const displayDiscountPrice = computed(
+  () => treatmentData.value?.discount_price_cents,
+);
 const displayTrajects = computed(() => treatmentData.value?.trajects || []);
-
 </script>
 
 <template>
-  <section class="not-prose bg-gradient-to-b from-secondary-200 to-primary-50 py-12 sm:py-16">
+  <section
+    class="not-prose bg-gradient-to-b from-secondary-200 to-primary-50 py-12 sm:py-16"
+  >
     <UContainer v-if="displayTitle">
-        <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 lg:gap-10 items-start">
-          <!-- Title Section -->
-          <div class="lg:col-span-2">
-            <div class="flex items-center gap-3 mb-6">
-            <UIcon v-if="displayIcon" :name="displayIcon" class="w-8 h-8 text-primary-600" aria-hidden="true" />
+      <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 lg:gap-10 items-start">
+        <!-- Title Section -->
+        <div class="lg:col-span-2">
+          <div class="flex items-center gap-3 mb-6">
+            <UIcon
+              v-if="displayIcon"
+              :name="displayIcon"
+              class="w-8 h-8 text-primary-600"
+              aria-hidden="true"
+            />
             <h1 class="text-4xl sm:text-5xl lg:text-6xl font-bold text-neutral-900">
               {{ displayTitle }}
             </h1>
           </div>
+          <p
+            v-if="subtitle"
+            class="text-lg sm:text-xl text-neutral-900 leading-relaxed mb-3"
+          >
+            {{ subtitle }}
+          </p>
           <p v-if="description" class="text-xl text-neutral-600 leading-relaxed">
             {{ description }}
           </p>

--- a/app/components/content/UitklapInfo.vue
+++ b/app/components/content/UitklapInfo.vue
@@ -142,6 +142,25 @@ const uniqueId = computed(() => {
   margin-bottom: 0.25rem;
 }
 
+
+.additional-info :deep(.prose a) {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px;
+  background: rgb(255 95 125);
+  color: white;
+  font-weight: 700;
+  padding: 0.75rem 1.25rem;
+  text-decoration: none;
+  box-shadow: 0 10px 15px -3px rgb(255 95 125 / 0.25);
+}
+
+.additional-info :deep(.prose a:hover) {
+  background: rgb(236 72 153);
+  color: white;
+}
+
 /* Responsive adjustments */
 @media (min-width: 1024px) {
   .additional-info :deep(h3) {

--- a/content/behandelingen/soulkey-therapy.md
+++ b/content/behandelingen/soulkey-therapy.md
@@ -1,0 +1,101 @@
+---
+title: SoulKey Therapy
+description: Regressietherapie, vorige levens, Life Between Lives en zielsbewustzijn voor diepe inzichten, persoonlijke ontwikkeling en het doorbreken van blokkades.
+---
+
+::behandeling-hero
+---
+title: SoulKey Therapy
+subtitle: Regressietherapie, Vorige levens, Life Between Lives & Zielsbewustzijn
+description: Een diepgaande vorm van regressietherapie voor zielsinzichten, persoonlijke ontwikkeling en het doorbreken van blokkades.
+id: soulkey-therapy
+---
+::
+
+::behandeling-sectie
+---
+image: /images/single-sessions-hypnotherapie.webp
+imageAlt: SoulKey Therapy sessie voor regressietherapie en zielsbewustzijn
+title: Wat kun je verwachten?
+---
+SoulKey Therapy is een zachte en diepgaande vorm van regressietherapie waarbij je wordt begeleid naar lagen van herinnering, gevoel en bewustzijn die voorbij het dagelijkse denken liggen. In een veilige, rustige setting onderzoeken we wat zich wil laten zien rondom jouw hulpvraag, zodat je meer inzicht, ontspanning en verbinding met jezelf kunt ervaren.
+::
+
+::twee-kolommen
+  :::voordelen-lijst
+  ---
+  items:
+    - Meer inzicht in terugkerende patronen en blokkades
+    - Diepere verbinding met je zielsbewustzijn
+    - Emotionele verwerking op jouw tempo
+    - Helderheid rondom levensvragen en persoonlijke thema's
+    - Meer rust, vertrouwen en innerlijke richting
+    - Bewustwording van oude lagen die nu losgelaten mogen worden
+  title: Wat je gaat merken
+  ---
+  :::
+
+  :::voor-wie
+  ---
+  items:
+    - Je steeds tegen dezelfde patronen of blokkades aanloopt
+    - Je verlangt naar meer inzicht in jezelf en je zielspad
+    - Je voelt dat oude ervaringen of onverklaarbare emoties doorwerken
+    - Je openstaat voor regressietherapie en vorige levens
+    - Je vragen hebt over Life Between Lives of zielsbewustzijn
+    - Je persoonlijke ontwikkeling op een diepere laag wilt onderzoeken
+  title: Voor wie?
+  ---
+  :::
+::
+
+::uitklap-info{title="Gratis kennismakings- en intakegesprek"}
+Twijfel je of SoulKey Therapy aansluit bij jouw hulpvraag of wil je eerst kennismaken? Voor iedere nieuwe cliënt plan ik een gratis en vrijblijvend kennismakings- en intakegesprek van 30 minuten via WhatsApp, met of zonder video. We bespreken jouw wensen en kijken samen of deze therapie past bij jouw persoonlijke situatie. Focus: Regressietherapie, zielsinzichten, persoonlijke ontwikkeling en het doorbreken van blokkades.
+
+[Plan je gratis kennismakingsgesprek](https://enisa-healing-massage.setmore.com)
+::
+
+::uitklap-info{title="Meer weten over SoulKey Therapy"}
+Tijdens een SoulKey Therapy sessie neem ik alle tijd om jou rustig te begeleiden. Je hoeft niets te forceren of te bedenken. We volgen wat zich op een natuurlijke manier aandient en werken alleen met wat jij nu kunt dragen en verwerken.
+
+### De drie lagen van SoulKey Therapy
+
+#### Vorige levens
+
+In regressie kunnen beelden, gevoelens of herinneringen uit vorige levens naar voren komen. Deze laag kan inzicht geven in onverklaarbare emoties, terugkerende patronen, relaties of blokkades die in dit leven nog voelbaar zijn.
+
+#### Life Between Lives
+
+Life Between Lives richt zich op de ruimte tussen levens. Deze laag kan helpen om meer helderheid te ervaren over zielsthema's, levenslessen, verbindingen met anderen en de diepere betekenis van jouw huidige leven.
+
+#### Zielsbewustzijn
+
+SoulKey Therapy helpt je contact te maken met je eigen zielsbewustzijn. Vanuit die verbinding ontstaat vaak meer rust, vertrouwen, zelfinzicht en richting in keuzes die bij jou passen.
+
+### Belangrijk om te weten
+
+- SoulKey Therapy is een persoonlijke en intuïtieve begeleiding, afgestemd op jouw tempo.
+- Je blijft tijdens de sessie aanwezig en behoudt altijd je eigen regie.
+- Je hoeft vooraf niet precies te weten wat er naar boven komt.
+- Iedere ervaring is uniek; sommige mensen zien beelden, anderen voelen vooral emoties, lichamelijke sensaties of innerlijk weten.
+- De sessie is bedoeld voor bewustwording, persoonlijke ontwikkeling en innerlijke verwerking.
+- SoulKey Therapy is complementair en vervangt geen medische of psychologische behandeling.
+::
+
+## Veelgestelde vragen
+
+::uitklap-info{title="Moet ik geloven in vorige levens om een sessie te doen?"}
+Nee. Een open, nieuwsgierige houding is voldoende. Je mag de ervaring ook zien als werken met beelden, symboliek, gevoel en onderbewuste lagen.
+::
+
+::uitklap-info{title="Blijf ik tijdens de sessie bij bewustzijn?"}
+Ja. Je blijft aanwezig en kunt reageren. Je behoudt altijd je eigen controle en bepaalt samen met mij het tempo.
+::
+
+::uitklap-info{title="Wat als er emoties loskomen?"}
+Emoties mogen er rustig zijn. Ik begeleid je stap voor stap en we werken alleen met wat op dat moment veilig en passend voelt.
+::
+
+::uitklap-info{title="Is een kennismakingsgesprek verplicht?"}
+Voor nieuwe cliënten plannen we eerst een gratis kennismakings- en intakegesprek. Zo kunnen we samen kijken of SoulKey Therapy aansluit bij jouw hulpvraag.
+::


### PR DESCRIPTION
### Motivation
- Align the SoulKey Therapy treatment page with the requested content and layout: shorten the H1 to “SoulKey Therapy” and show the rest as a subtitle, replace/rename intro and pricing sections into the requested headings and a free intake accordion, move benefit/for‑who sections into a Chakra‑Healing style two‑column layout, consolidate the “Meer weten” content and remove redundant/process/preparation sections, and convert the FAQ into accordions.

### Description
- Added `content/behandelingen/soulkey-therapy.md` with the new structure including the hero metadata (`title`, `subtitle`), `Wat kun je verwachten?` section, `twee-kolommen` cards for “Wat je gaat merken” and “Voor wie?”, a `Gratis kennismakings- en intakegesprek` accordion with CTA link, a combined `Meer weten` accordion (three layers + important notes), and FAQ accordions.
- Updated `app/components/content/BehandelingHero.vue` to accept content-provided `title` and `subtitle` and to prefer content-provided values while preserving database-backed treatment details; DB fetching is now conditional (only when `id` looks like a UUID) and injected DB data is still used as a fallback for SEO/consistency.
- Adjusted `app/components/content/UitklapInfo.vue` styles to render links inside expandable content as CTA‑style buttons so that the intake link appears as a visual button inside the accordion.
- Removed duplicated and now‑unneeded content blocks from the treatment file and reorganized material into the requested accordions and two‑column layout.

### Testing
- `bun install` completed successfully.
- `bun run build` completed successfully and produced a local Nitro preview build.
- Playwright browser install and deps succeeded and a screenshot command was executed (screenshot saved to `/tmp/soulkey-therapy.png`), but the page rendered HTTP 500 during server-rendered preview because required Supabase server environment variables are not present, so visual verification on this environment is incomplete.
- `bunx eslint app/components/content/BehandelingHero.vue app/components/content/UitklapInfo.vue` failed due to an ESLint configuration import error referencing `.nuxt/eslint.config.mjs`, so linting needs to be addressed in CI or local environment before merging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a351b50d73c83239b83438a36d29797)