### PR TITLE
fix: werk kwalificaties op Over mij pagina bij

### DIFF
--- a/app/pages/over-mij.vue
+++ b/app/pages/over-mij.vue
@@ -20,7 +20,7 @@ const personSchema = {
   hasCredential: [
     {
       "@type": "EducationalOccupationalCredential",
-      name: "Gecertificeerd SoulKey Therapy Practitioner (SoulKey Academy, opgeleid door Peter Kupers)",
+      name: "Gecertificeerd SoulKey Therapy Practitioner Regressietherapie (SoulKey Academy)",
       credentialCategory: "Professional Certification",
     },
     {
@@ -30,7 +30,7 @@ const personSchema = {
     },
     {
       "@type": "EducationalOccupationalCredential",
-      name: "Gecertificeerd Mindfulness MBSR Trainer (Centrum voor Mindfulness Amsterdam, opgeleid door drs. Rob Brandsma)",
+      name: "Gecertificeerd Mindfulness MBSR Trainer (Centrum voor Mindfulness Amsterdam)",
       credentialCategory: "Professional Certification",
     },
     {
@@ -195,8 +195,8 @@ setPageSEO({
                   class="w-5 h-5 text-green-500 mt-0.5"
                 />
                 <span class="text-neutral-600"
-                  >Gecertificeerd SoulKey Therapy Practitioner (SoulKey Academy,
-                  opgeleid door Peter Kupers)</span
+                  >Gecertificeerd SoulKey Therapy Practitioner Regressietherapie
+                  (SoulKey Academy)</span
                 >
               </li>
               <li class="flex items-start gap-3">
@@ -215,7 +215,7 @@ setPageSEO({
                 />
                 <span class="text-neutral-600"
                   >Gecertificeerd Mindfulness MBSR Trainer (Centrum voor Mindfulness
-                  Amsterdam, opgeleid door drs. Rob Brandsma)</span
+                  Amsterdam)</span
                 >
               </li>
               <li class="flex items-start gap-3">


### PR DESCRIPTION
### Motivation
- Synchroniseer de zichtbare kwalificatielijst en de bijbehorende structured data in `app/pages/over-mij.vue` met de aangeleverde copy, waaronder toevoeging van “Regressietherapie” voor SoulKey en het verwijderen van opleidersnamen.

### Description
- Pas `personSchema.hasCredential` in `app/pages/over-mij.vue` aan zodat de SoulKey-credential de tekst `Gecertificeerd SoulKey Therapy Practitioner Regressietherapie (SoulKey Academy)` bevat en de Mindfulness-entry geen opleidersnaam meer vermeldt.
- Werk de zichtbare lijst onder de sectie «Kwalificaties» in `app/pages/over-mij.vue` bij zodat de weergegeven tekst exact overeenkomt met de aangepaste metadata.
- Er zijn geen layout-, component- of API-wijzigingen; alleen tekst en bijbehorende JSON-LD in hetzelfde bestand werden aangepast.

### Testing
- `git diff --check` — geslaagd.
- `rg -n 'SoulKey Therapy Practitioner Regressietherapie|Ericksoniaanse Hypnose|Mindfulness MBSR Trainer|Wellnessmasseur' app/pages/over-mij.vue` — geslaagd en bevestigt de nieuwe formuleringen.
- `bun run build` — productiebuild voltooid succesvol, met alleen bestaande waarschuwingen over ontbrekende Supabase keys en externe font providers.
- `bunx eslint app/pages/over-mij.vue` — niet geslaagd vanwege een bestaande ongeldige import `.nuxt/eslint.config.mjs` in `eslint.config.mjs` (extern probleem, niet veroorzaakt door deze tekstwijziging).
- Lokale pagina-render (via dev server + `curl`) — niet volledig verifieerbaar doordat de dev server tijdens SSR een bestaande Pinia-fout (`Cannot read properties of undefined (reading 'state')`) retourneerde; dit is een pre‑bestaand probleem en ligt buiten deze tekstwijziging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a705807e2948323afb7db3ccabe0e1b)