### PR TITLE
fix(content): update 'Wat kun je verwachten' for energetische-blokkades-opheffen

### DIFF
--- a/content/behandelingen/energetische-blokkades-opheffen.md
+++ b/content/behandelingen/energetische-blokkades-opheffen.md
@@ -13,15 +13,17 @@ id: da84341d-d8cd-4db7-bacf-7d2495ecccb4
 ::behandeling-sectie
 ---
 items:
-  - "Sessie 1 (120 min): Meditatie gecombineerd met chakra healing"
-  - "Sessie 2 (120 min): Meditatie en healing voor diepere verwerking"
-  - "Sessie 3 (120 min): Twee meditaties om het proces te integreren met healing"
-  - "Traject: 3 sessies voor €480 (Losse sessies: €160 per sessie)"
+  - "Sessie 1 (90 min): Meditatie gecombineerd met chakra healing – €135"
+  - "Sessie 2 (90 min): Meditatie en healing voor diepere verwerking – €135"
+  - "Sessie 3 (90 min): Twee meditaties om het proces te integreren – €135"
+  - "Sessie 4 (60 min): Afrondende chakra healing behandeling – €85"
+  - "Ook te boeken als traject:"
+  - "3 sessies van 2 uur – €160 per sessie"
 image: /images/loslaten-traject.webp
 imageAlt: Traject voor het opheffen van energetische blokkades in Amsterdam Noord
 title: Wat kun je verwachten?
 ---
-Het traject Energetische blokkades opheffen in mijn praktijk in Amsterdam Noord bestaat uit drie sessies waarin je stap voor stap werkt aan het losmaken van oude patronen en vastzittende energie. Met een combinatie van meditaties en healings ontstaat er meer ruimte, helderheid en innerlijke rust. Loslaten betekent niet vergeten, maar kiezen voor jezelf en verdergaan met vertrouwen.
+Het traject Energetische blokkades opheffen in mijn praktijk in Amsterdam Noord bestaat uit vier sessies waarin je stap voor stap werkt aan het losmaken van oude patronen en vastzittende energie. Met een combinatie van meditaties en healings ontstaat er meer ruimte, helderheid en innerlijke rust. Loslaten betekent niet vergeten, maar kiezen voor jezelf en verdergaan met vertrouwen.
 ::
 
 ::twee-kolommen


### PR DESCRIPTION
### Motivation

- Het behandelingsblok moest up-to-date worden met de juiste sessie-opbouw, duur en prijzen zodat de pagina overeenkomt met het actuele aanbod.
- De tekst moest uitbreiden van een traject met drie sessies naar een traject met vier sessies en een alternatieve trajectoptie communiceren.

### Description

- Bijgewerkt `content/behandelingen/energetische-blokkades-opheffen.md` door de sessielijst te vervangen en de introductie te wijzigen naar een vier-sessies traject.
- Toegevoegd: `Sessie 4 (60 min): Afrondende chakra healing behandeling – €85` en de alternatieve optie `3 sessies van 2 uur – €160 per sessie` in de sectie `Wat kun je verwachten?`.
- De bestaande pagina-structuur, frontmatter en `::behandeling-hero` `id` zijn behouden; alleen content (kopjes en lijstitems) is aangepast.

### Testing

- `git diff --check` uitgevoerd en geen content-syntax fouten gevonden.
- `bun install --frozen-lockfile` uitgevoerd en voltooid zonder fouten.
- `bun run build` uitgevoerd en de build is voltooid; er verschenen alleen bekende waarschuwingen over externe font-providers en ontbrekende Supabase/Studio env-configs, maar de build slaagde.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a784833755c8323ba5c3deb770f17b2)