### PR TITLE
fix(content): vermeld tijdelijke trajectkorting op Energetische blokkades-pagina

### DIFF
--- a/content/behandelingen/energetische-blokkades-opheffen.md
+++ b/content/behandelingen/energetische-blokkades-opheffen.md
@@ -19,6 +19,7 @@ items:
   - "Sessie 4 (60 min): Afrondende chakra healing behandeling – €85"
   - "Ook te boeken als traject:"
   - "3 sessies van 2 uur – €160 per sessie"
+  - "Tijdelijk €30 korting op het volledige traject"
 image: /images/loslaten-traject.webp
 imageAlt: Traject voor het opheffen van energetische blokkades in Amsterdam Noord
 title: Wat kun je verwachten?


### PR DESCRIPTION
### Motivation
- Voeg een tijdelijke kortingsvermelding toe in de sectie "Wat kun je verwachten?" van de behandelingspagina zodat bezoekers de actie direct zien.

### Description
- Toegevoegd in `content/behandelingen/energetische-blokkades-opheffen.md` de regel `- "Tijdelijk €30 korting op het volledige traject"` direct onder de trajectprijs.

### Testing
- Gecontroleerd met `rg -n -C 2 '3 sessies van 2 uur|Tijdelijk €30 korting'`, `git diff --check` en `git status` (succes), de wijziging is gecommit met bericht `fix(content): vermeld tijdelijke trajectkorting`, en `bun run build` faalde omdat `nuxt` niet gevonden werd (projectafhankelijkheden niet geïnstalleerd).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a787c1d29bc8323ab80a30ab595d3d7)