### PR TITLE
fix(content): nuanceer tekst in sectie 'Vorige levens'

### DIFF
--- a/content/behandelingen/regressietherapie-soulkey-therapy.md
+++ b/content/behandelingen/regressietherapie-soulkey-therapy.md
@@ -99,7 +99,7 @@ title: Belangrijk om te weten
 
 ### Vorige levens
 
-Tijdens de sessie kan er een spontane regressie ontstaan naar ervaringen uit vorige levens. Dit helpt om huidige angsten, relaties of onverklaarbare gevoelens in een heel nieuw daglicht te zien. De therapeutische waarde ligt in de betekenis en de bevrijding die deze herinneringen brengen voor het leven dat je nu leidt.
+Tijdens de sessie kan er een spontane regressie ontstaan naar ervaringen die zich aandienen als een vorig leven. Dit kan helpen om terugkerende patronen, angsten, relaties of emoties vanuit een nieuw perspectief te begrijpen. De therapeutische waarde ligt in de inzichten die bijdragen aan jouw leven van nu.
 
 ### Life Between Lives
 


### PR DESCRIPTION
### Motivation

- De tekst in de sectie "Vorige levens" van de behandelingspagina moest minder stellig en meer genuanceerd verwoord worden zodat inzichten en perspectief voor de cliënt beter worden benadrukt.

### Description

- Vervangen van de alinea onder `### Vorige levens` in `content/behandelingen/regressietherapie-soulkey-therapy.md` door de doorgegeven, meer genuanceerde formulering; de rest van de pagina-structuur en frontmatter zijn ongewijzigd.

### Testing

- Uitgevoerd: een Python-inhoudscontrole die bevestigt dat de oude tekst niet meer aanwezig is en de nieuwe tekst exact één keer voorkomt, en `git diff --check` voor whitespace/format checks; beide controles zijn geslaagd.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7d89909b008323893c8f4973711637)