### PR TITLE
fix(content): update Life Between Lives copy

### DIFF
--- a/content/behandelingen/regressietherapie-soulkey-therapy.md
+++ b/content/behandelingen/regressietherapie-soulkey-therapy.md
@@ -103,7 +103,7 @@ Tijdens de sessie kan er een spontane regressie ontstaan naar ervaringen die zic
 
 ### Life Between Lives
 
-Deze laag geeft toegang tot de periode tussen levens in: het bestaan als ziel. Veel cliënten ervaren hier ontmoetingen met hun zielengroep of gidsen en krijgen heldere antwoorden over de keuzes en afspraken die voorafgaand aan dit huidige leven zijn gemaakt.
+Life Between Lives richt zich op de periode tussen levens. Veel mensen ervaren hier een diep gevoel van rust, verbondenheid en inzicht. Sommigen beleven een ontmoeting die zij ervaren als een gids, zielengroep of een andere vorm van bewustzijn. Anderen ontvangen juist waardevolle inzichten, gevoelens of een diep innerlijk weten. Iedere ervaring is persoonlijk en ontstaat op een natuurlijke manier, zonder vooraf te worden ingevuld.
 
 ### Zielsbewustzijn
 


### PR DESCRIPTION
### Motivation

- Update the copy for the "Life Between Lives" section to the provided, more nuanced and person-centered Dutch text.

### Description

- Replaced the paragraph under `### Life Between Lives` in `content/behandelingen/regressietherapie-soulkey-therapy.md` with the new supplied text. 
- Preserved the surrounding structure, section titles, frontmatter and other page content.

### Testing

- Ran repository checks with `git diff --check` and `git status` to ensure no whitespace or index issues, and they passed. 
- Verified the updated block with a search for `### Life Between Lives`, which shows the new paragraph in the target file. 
- Executed `bun run build` which failed because `nuxt` is not available in the current environment (build exited with code 127).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7d905812d48323b729e4bfa75e4b77)