### PR TITLE
fix(content): update Zielsbewustzijn copy on Regressietherapie (SoulKey Therapy) page

### DIFF
--- a/content/behandelingen/regressietherapie-soulkey-therapy.md
+++ b/content/behandelingen/regressietherapie-soulkey-therapy.md
@@ -107,7 +107,7 @@ Life Between Lives richt zich op de periode tussen levens. Veel mensen ervaren h
 
 ### Zielsbewustzijn
 
-Hier stem je direct af op de wijsheid van jouw eigen ziel. Het helpt je stil te staan bij vragen zoals: Welke lessen mag ik hier leren? Wat past werkelijk bij mij? En hoe kan ik volledig in mijn eigen kracht gaan staan? Dit zorgt voor een sterke verankering van zelfvertrouwen en innerlijke rust.
+Zielsbewustzijn nodigt je uit om contact te maken met de wijsheid van jouw eigen ziel en vanuit een ruimer perspectief naar jezelf en jouw leven te kijken. Er kan ruimte ontstaan voor diepere inzichten over wie je bent, wat werkelijk bij je past en welke richting je in je leven wilt volgen. Het nodigt je uit om stil te staan bij vragen zoals: Welke lessen mag ik hier leren? Wat geeft mij energie? En hoe kan ik meer leven vanuit vertrouwen en mijn eigen kracht? Dit kan bijdragen aan meer zelfvertrouwen, innerlijke rust en het maken van bewustere keuzes.
 ::
 
 ::uitklap-info{title="Veelgestelde vragen"}


### PR DESCRIPTION
### Motivation
- De korte alinea onder het kopje `Zielsbewustzijn` vervangen door de aangeleverde, uitgebreidere tekst om bezoekers een ruimer en concreter beeld te geven van wat zielsbewustzijn biedt.
- De wijziging beperkt zich tot content en behoudt de bestaande Nuxt Content-structuur en metadata van de pagina.

### Description
- Vervangen van de tekst onder `### Zielsbewustzijn` in `content/behandelingen/regressietherapie-soulkey-therapy.md` met de nieuwe, door de gebruiker aangeleverde copy.
- Er zijn geen wijzigingen doorgevoerd in frontmatter, componenten, routes of afbeeldingen, en de pagina-structuur is intact gebleven.

### Testing
- Uitgevoerd `git diff --check` met geen fouten gerapporteerd.
- Gecontroleerd met `rg -n -A 2 '^### Zielsbewustzijn$' content/behandelingen/regressietherapie-soulkey-therapy.md` dat de nieuwe tekst aanwezig is en de oude tekst niet meer voorkomt.
- Bekeken met `git status --short` en `git log -1 --oneline` om de repositorystatus en laatste wijziging te verifiëren.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7d9f65a5b483238a2010593f077c2f)